### PR TITLE
Add cross-platform native ops and TensorRT export

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ mature open-source projects (Ultralytics, MMDetection/MMEngine, Detectron2, Open
 Transformers) without deriving from their code; RT-DETR serves as the research baseline that
 LOFOP-Detect is designed against, never copied.
 
-> **Status:** Phases 1-5 complete — core engine, data subsystem, native C++ ops, LOFOP-Detect
-> models, training engine, and ONNX export. 184 tests passing. See
+> **Status:** Phases 1-5 complete — core engine, data subsystem, cross-platform native ops,
+> LOFOP-Detect models, training engine, and ONNX + TensorRT export. 196 tests passing. See
 > [`docs/architecture.md`](docs/architecture.md) for the full roadmap and per-phase status.
 
 ## What works today
@@ -21,13 +21,16 @@ LOFOP-Detect is designed against, never copied.
 - **Training** — AMP, EMA weights, warmup+cosine schedule, gradient clipping, atomic
   checkpointing with resume, event-bus lifecycle hooks, and a COCO-protocol evaluator
   (mAP@50, mAP@50:95, precision, recall).
-- **Native C++ ops** — IoU and class-aware NMS kernels (20-200x over pure Python) with a
-  verified-identical Python fallback, so a compiler is never required.
+- **Cross-platform native ops** — IoU and class-aware NMS kernels (20-200x over pure Python) with a
+  verified-identical Python fallback, so a compiler is never required. The C++ path builds with
+  g++/clang on Linux/macOS and MinGW/clang/MSVC on Windows; `lofop.ops.backend()` reports which is
+  active.
 - **Benchmarking** — `lofop benchmark` renders the standard metric table (mAP, FPS, params,
   FLOPs, model size) and never prints a number that was not actually measured.
-- **ONNX export** — `lofop export` writes a numerically verified ONNX graph (network + box
-  decoding); `postprocess_dense` finishes inference torch-free with the C++ NMS, so serving
-  hosts need only onnxruntime + the LOFOP core. Details: [`docs/deploy.md`](docs/deploy.md).
+- **ONNX + TensorRT export** — `lofop export` writes a numerically verified ONNX graph (network +
+  box decoding), or a TensorRT engine (`--format tensorrt --fp16`) via that same ONNX;
+  `postprocess_dense` finishes inference torch-free with the C++ NMS, so serving hosts need only a
+  runtime + the LOFOP core. Details: [`docs/deploy.md`](docs/deploy.md).
 - **Deployment scaffolding** — CPU / CUDA / ONNX Runtime Docker images ([`docker/`](docker/README.md)).
 
 ## Installation
@@ -57,6 +60,7 @@ lofop dataset stats    --format coco --source instances.json -o stats.md
 python examples/train_shapes.py --epochs 30 --workdir runs/shapes
 lofop benchmark --config configs/lofop-detect/n.yaml --config configs/lofop-detect/s.yaml -o table.md
 lofop export --config configs/lofop-detect/n.yaml --checkpoint runs/shapes/checkpoints/best.pt -o model.onnx
+lofop export --config configs/lofop-detect/n.yaml --format tensorrt --fp16 -o model.engine   # NVIDIA GPU
 ```
 
 Measured on this repo's CI-sized shapes demo (30 CPU epochs, 128px): mAP@50 0.73,
@@ -93,7 +97,7 @@ lofop/
   data/          # canonical dataset model, COCO/YOLO/VOC adapters, validator, statistics
   models/        # LOFOP-Detect: RidgeNet, DeltaFusion, ApexHead, losses, assigner
   training/      # trainer, EMA, checkpoints, torch data bridge, COCO-protocol evaluator
-  deploy/        # ONNX export + torch-free post-processing
+  deploy/        # ONNX + TensorRT export, torch-free post-processing
   ops/ + csrc/   # native C++ IoU/NMS with Python fallback
   utils/         # model benchmarking (metric table, FLOPs, FPS)
   cli.py         # `lofop` command: dataset / train / benchmark / export
@@ -117,7 +121,7 @@ python benchmarks/bench_detect.py                  # detector params + latency
 
 ## Roadmap
 
-Next phases: inference sources (video/RTSP/webcam), TensorRT/OpenVINO engines, REST serving, and CI.
+Next phases: inference sources (video/RTSP/webcam), OpenVINO engines, REST serving, and CI.
 The full subsystem map with per-phase status lives in [`docs/architecture.md`](docs/architecture.md).
 
 ## License

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,10 +33,10 @@ and the build order. Module-level documents (e.g. [`core-engine.md`](core-engine
 | 3 | `lofop.models` | LOFOP-Detect: RidgeNet, DeltaFusion, ApexHead, losses, dynamic assignment | **Done** (see docs/lofop-detect.md) |
 | 4 | `lofop.training` | Trainer (AMP, EMA, cosine schedule, resume), COCO-protocol evaluator, checkpoints, torch data bridge | **Done** (DDP path present, not CI-exercised) |
 | 5 | `lofop.inference` | Image/video/stream predictors, batching, RTSP/webcam sources | Planned |
-| 6 | `lofop.deploy` | ONNX export + torch-free post-processing done; TensorRT/OpenVINO/REST planned | In progress (see docs/deploy.md) |
+| 6 | `lofop.deploy` | ONNX + TensorRT export and torch-free post-processing done; OpenVINO/REST planned | In progress (see docs/deploy.md) |
 | 7 | `lofop.cli` | `lofop` CLI (`dataset` tools done; `train`/`predict`/`export` planned) | In progress |
 | 8 | `lofop.utils` | Model benchmarking (metric table, FLOPs, FPS, size) done; visualization planned | In progress |
-| -- | `lofop.ops` | Native C++ box ops (IoU, NMS, class-aware NMS) with Python fallback | **Done** |
+| -- | `lofop.ops` | Cross-platform native C++ box ops (IoU, NMS) with Python fallback; MSVC/MinGW/g++/clang | **Done** |
 
 Each phase lands with its own tests and docs before the next begins. Dependencies point downward
 only: `data`/`models`/`training` depend on `core`, never on each other's internals; interaction

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -46,7 +46,49 @@ detections.boxes, detections.scores, detections.labels     # final results
 onnxruntime + LOFOP-core inference stack has no deep-learning-framework dependency. This is
 exactly the stack the `docker/Dockerfile-onnx` image ships.
 
+## TensorRT export
+
+```bash
+lofop export --config configs/lofop-detect/s.yaml --checkpoint best.pt \
+    --format tensorrt --fp16 -o model.engine
+```
+
+```python
+from lofop.deploy import export_tensorrt
+export_tensorrt(model, "model.engine", image_size=640, fp16=True)
+```
+
+Export is two-stage by design: **model -> ONNX -> engine**, reusing the same verified ONNX graph
+so the ONNX Runtime and TensorRT paths share one source of truth and one post-processing routine.
+Notes:
+
+- **FP16** is a single builder flag -- large speedup on NVIDIA hardware, negligible accuracy cost
+  for detectors.
+- **INT8** additionally needs representative calibration data
+  (`export_tensorrt(..., int8=True, calibration_inputs=[...])`); a minimal entropy calibrator
+  consumes the provided `(1, 3, S, S)` arrays.
+- TensorRT and a CUDA GPU are needed only for the engine-build step. The module imports without
+  them, the ONNX intermediate is always produced first, and a missing `tensorrt` package raises a
+  clear, actionable error instead of an opaque `ImportError`.
+- Engines are GPU- and TensorRT-version-specific -- build on the target hardware.
+
+## Native ops portability
+
+Post-processing NMS/IoU run through the native C++ fast path when the library is built, and
+through the pure-Python fallback otherwise -- on every OS. The builder auto-selects a toolchain:
+`g++`/`clang++`/`c++` on Linux/macOS, and `g++`/`clang++` (MinGW/LLVM) or MSVC `cl.exe` on Windows.
+Check which backend is live:
+
+```python
+from lofop.ops import backend, build_native
+build_native()      # optional; compiles the C++ library if a compiler is present
+print(backend())    # "native" or "python"
+```
+
+Nothing requires the C++ path -- it is a pure accelerator. `lofop.ops` and
+`postprocess_dense` work identically either way.
+
 ## Roadmap
 
-TensorRT and OpenVINO engine builders consume the same ONNX artifact (planned); TorchScript
-export is planned for torch-native serving.
+OpenVINO engine builders consume the same ONNX artifact (planned); TorchScript export is planned
+for torch-native serving.

--- a/lofop/cli.py
+++ b/lofop/cli.py
@@ -78,13 +78,17 @@ def build_parser() -> argparse.ArgumentParser:
     bench.add_argument("--checkpoint", default=None, help="weights (best.pt/last.pt) to load")
     bench.add_argument("-o", "--output", type=Path, default=None, help="write the table here")
 
-    export = commands.add_parser("export", help="export a detector to ONNX")
+    export = commands.add_parser("export", help="export a detector to ONNX or TensorRT")
     export.add_argument("--config", required=True, help="model config YAML")
     export.add_argument("--checkpoint", default=None, help="weights (best.pt/last.pt) to load")
+    export.add_argument(
+        "--format", choices=["onnx", "tensorrt"], default="onnx", help="export format",
+    )
     export.add_argument("--size", type=int, default=640, help="input resolution for the graph")
     export.add_argument("--opset", type=int, default=18, help="ONNX opset version")
     export.add_argument("--no-verify", action="store_true", help="skip onnxruntime verification")
-    export.add_argument("-o", "--output", type=Path, required=True, help="output .onnx path")
+    export.add_argument("--fp16", action="store_true", help="TensorRT: enable FP16 kernels")
+    export.add_argument("-o", "--output", type=Path, required=True, help="output path")
     return parser
 
 
@@ -185,7 +189,6 @@ def _cmd_export(args: argparse.Namespace) -> int:
 
     import lofop.models  # noqa: F401  (registers model components)
     from lofop.core.config import Config
-    from lofop.deploy import export_onnx
     from lofop.registries import HUB
 
     cfg = Config.load(args.config)
@@ -194,6 +197,17 @@ def _cmd_export(args: argparse.Namespace) -> int:
         payload = torch.load(args.checkpoint, map_location="cpu", weights_only=True)
         state = payload.get("ema", {}).get("module", payload.get("model", payload))
         model.load_state_dict(state)
+
+    if args.format == "tensorrt":
+        from lofop.deploy import export_tensorrt
+
+        path = export_tensorrt(model, args.output, image_size=args.size, fp16=args.fp16)
+        size_mb = path.stat().st_size / 1e6
+        print(f"Exported TensorRT engine {path} ({size_mb:.1f} MB, fp16={args.fp16})")
+        return 0
+
+    from lofop.deploy import export_onnx
+
     path = export_onnx(
         model, args.output, image_size=args.size, opset=args.opset,
         verify=not args.no_verify,

--- a/lofop/deploy/__init__.py
+++ b/lofop/deploy/__init__.py
@@ -7,12 +7,24 @@ framework beside their ONNX runtime.
 
 from lofop.deploy.postprocess import Detections, postprocess_dense
 
-__all__ = ["Detections", "postprocess_dense", "export_onnx", "DenseExportWrapper"]
+__all__ = [
+    "Detections", "postprocess_dense",
+    "export_onnx", "DenseExportWrapper",
+    "export_tensorrt", "build_engine_from_onnx",
+]
+
+_ONNX_EXPORTS = {"export_onnx", "DenseExportWrapper"}
+_TRT_EXPORTS = {"export_tensorrt", "build_engine_from_onnx"}
 
 
 def __getattr__(name: str):
-    if name in ("export_onnx", "DenseExportWrapper"):
+    # Lazy so importing lofop.deploy never requires torch/tensorrt.
+    if name in _ONNX_EXPORTS:
         from lofop.deploy import onnx_export
 
         return getattr(onnx_export, name)
+    if name in _TRT_EXPORTS:
+        from lofop.deploy import tensorrt_export
+
+        return getattr(tensorrt_export, name)
     raise AttributeError(f"module 'lofop.deploy' has no attribute {name!r}")

--- a/lofop/deploy/tensorrt_export.py
+++ b/lofop/deploy/tensorrt_export.py
@@ -1,0 +1,186 @@
+"""TensorRT export for LOFOP detectors.
+
+TensorRT is NVIDIA's inference optimizer: it consumes an ONNX graph and emits
+a serialized ``.engine`` tuned for a specific GPU, typically the fastest way
+to run a detector on NVIDIA hardware. LOFOP exports in two stages -- model ->
+ONNX (via :mod:`lofop.deploy.onnx_export`), then ONNX -> engine here -- so the
+same verified ONNX graph feeds both the ONNX Runtime and TensorRT paths, and
+post-processing (:func:`lofop.deploy.postprocess.postprocess_dense`) is shared
+across runtimes.
+
+TensorRT and a CUDA GPU are required only for the engine-build step; the
+module imports without them, and the ONNX intermediate is produced regardless
+so failures are localized to the GPU-specific stage. FP16 is a single builder
+flag; INT8 additionally needs representative calibration data.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from lofop.core.exceptions import LofopError
+from lofop.core.logging import get_logger
+from lofop.deploy.onnx_export import export_onnx
+
+if TYPE_CHECKING:
+    from torch import nn
+
+logger = get_logger(__name__)
+
+# Default TensorRT builder workspace (bytes). 1 GiB suits the LOFOP-Detect
+# family; raise for larger models or more aggressive tactic search.
+_DEFAULT_WORKSPACE = 1 << 30
+
+
+def export_tensorrt(
+    model: nn.Module,
+    engine_path: str | Path,
+    *,
+    image_size: int = 640,
+    fp16: bool = False,
+    int8: bool = False,
+    calibration_inputs: Sequence | None = None,
+    workspace: int = _DEFAULT_WORKSPACE,
+    onnx_path: str | Path | None = None,
+    keep_onnx: bool = False,
+) -> Path:
+    """Export a detector to a TensorRT engine (via an ONNX intermediate).
+
+    Args:
+        model: Detector to export (weights already loaded).
+        engine_path: Output ``.engine`` path.
+        image_size: Fixed input resolution baked into the graph.
+        fp16: Enable FP16 kernels (large speedup, negligible accuracy cost on
+            most detectors).
+        int8: Enable INT8 kernels; requires ``calibration_inputs``.
+        calibration_inputs: Sequence of representative ``(1, 3, S, S)`` input
+            arrays used to calibrate INT8 dynamic ranges.
+        workspace: Builder workspace memory budget in bytes.
+        onnx_path: Where to write the intermediate ONNX; defaults to the
+            engine path with a ``.onnx`` suffix.
+        keep_onnx: Keep the intermediate ONNX file after building the engine.
+
+    Returns:
+        The written engine path.
+
+    Raises:
+        LofopError: If TensorRT is unavailable, INT8 is requested without
+            calibration data, or the build fails.
+    """
+    if int8 and not calibration_inputs:
+        raise LofopError("INT8 export requires calibration_inputs with representative data")
+
+    engine_path = Path(engine_path)
+    intermediate = Path(onnx_path) if onnx_path else engine_path.with_suffix(".onnx")
+    export_onnx(model, intermediate, image_size=image_size, verify=False)
+    try:
+        build_engine_from_onnx(
+            intermediate, engine_path, fp16=fp16, int8=int8,
+            calibration_inputs=calibration_inputs, workspace=workspace,
+        )
+    finally:
+        if not keep_onnx and intermediate.exists():
+            intermediate.unlink()
+    return engine_path
+
+
+def build_engine_from_onnx(
+    onnx_path: str | Path,
+    engine_path: str | Path,
+    *,
+    fp16: bool = False,
+    int8: bool = False,
+    calibration_inputs: Sequence | None = None,
+    workspace: int = _DEFAULT_WORKSPACE,
+) -> Path:
+    """Build a serialized TensorRT engine from an existing ONNX file.
+
+    Raises:
+        LofopError: If TensorRT is not importable or the build fails.
+    """
+    trt = _import_tensorrt()
+    onnx_path, engine_path = Path(onnx_path), Path(engine_path)
+    if not onnx_path.is_file():
+        raise LofopError("ONNX file not found for engine build", context={"onnx": str(onnx_path)})
+
+    trt_logger = trt.Logger(trt.Logger.WARNING)
+    builder = trt.Builder(trt_logger)
+    flag = 1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH)
+    network = builder.create_network(flag)
+    parser = trt.OnnxParser(network, trt_logger)
+    if not parser.parse(onnx_path.read_bytes()):
+        errors = [str(parser.get_error(i)) for i in range(parser.num_errors)]
+        raise LofopError("TensorRT failed to parse ONNX", context={"errors": errors})
+
+    config = builder.create_builder_config()
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace)
+    if fp16:
+        if not builder.platform_has_fast_fp16:
+            logger.warning("Platform reports no fast FP16; enabling anyway")
+        config.set_flag(trt.BuilderFlag.FP16)
+    if int8:
+        config.set_flag(trt.BuilderFlag.INT8)
+        config.int8_calibrator = _make_calibrator(trt, network, calibration_inputs)
+
+    engine_path.parent.mkdir(parents=True, exist_ok=True)
+    serialized = builder.build_serialized_network(network, config)
+    if serialized is None:
+        raise LofopError("TensorRT engine build returned no result")
+    engine_path.write_bytes(serialized)
+    logger.info(
+        "Built TensorRT engine at %s (%.1f MB, fp16=%s, int8=%s)",
+        engine_path, engine_path.stat().st_size / 1e6, fp16, int8,
+    )
+    return engine_path
+
+
+def _import_tensorrt():
+    try:
+        import tensorrt as trt
+
+        return trt
+    except ImportError as exc:
+        raise LofopError(
+            "TensorRT is not installed. Install the NVIDIA 'tensorrt' package "
+            "on a CUDA-capable machine to build engines.",
+        ) from exc
+
+
+def _make_calibrator(trt, network, calibration_inputs: Sequence):
+    """Build a minimal entropy calibrator over provided input arrays."""
+    import numpy as np
+    from cuda import cudart  # provided by the tensorrt/cuda stack
+
+    input_tensor = network.get_input(0)
+    shape = tuple(input_tensor.shape)
+
+    class _EntropyCalibrator(trt.IInt8EntropyCalibrator2):
+        def __init__(self) -> None:
+            super().__init__()
+            self._batches = iter(calibration_inputs)
+            nbytes = int(np.prod(shape)) * np.dtype(np.float32).itemsize
+            self._device_input = cudart.cudaMalloc(nbytes)[1]
+
+        def get_batch_size(self) -> int:
+            return shape[0]
+
+        def get_batch(self, names):
+            try:
+                batch = np.ascontiguousarray(next(self._batches), dtype=np.float32)
+            except StopIteration:
+                return None
+            cudart.cudaMemcpy(
+                self._device_input, batch.ctypes.data, batch.nbytes,
+                cudart.cudaMemcpyKind.cudaMemcpyHostToDevice,
+            )
+            return [int(self._device_input)]
+
+        def read_calibration_cache(self):
+            return None
+
+        def write_calibration_cache(self, cache):
+            return None
+
+    return _EntropyCalibrator()

--- a/lofop/ops/__init__.py
+++ b/lofop/ops/__init__.py
@@ -6,6 +6,9 @@ drop-in C++ fast path producing identical results.
 """
 
 from lofop.ops.boxes import batched_nms, iou_matrix, nms
-from lofop.ops.native import build_native, find_library, load_native
+from lofop.ops.native import backend, build_native, find_library, load_native
 
-__all__ = ["iou_matrix", "nms", "batched_nms", "build_native", "find_library", "load_native"]
+__all__ = [
+    "iou_matrix", "nms", "batched_nms",
+    "backend", "build_native", "find_library", "load_native",
+]

--- a/lofop/ops/native.py
+++ b/lofop/ops/native.py
@@ -1,24 +1,34 @@
 """Build and load the native C++ ops library.
 
 The C++ core is optional by design: every op in :mod:`lofop.ops` has a pure
-Python reference implementation, and the native library is a drop-in
-accelerator loaded through ctypes. This keeps LOFOP importable on machines
-with no compiler while letting deployments (and the Docker images) opt into
-native speed with one call::
+Python reference implementation (always available, works on every platform),
+and the native library is a drop-in accelerator loaded through ctypes. LOFOP
+therefore runs everywhere, and *additionally* gets 20-200x faster box ops
+when a C++ toolchain is present and the library is built::
 
     python -c "from lofop.ops.native import build_native; build_native()"
 
-The compiled library lands next to this module as ``_lofop_ops.so`` (or in
-``~/.cache/lofop`` when the package directory is read-only) and is picked up
-automatically on the next import.
+Toolchains supported, tried in this order (override with ``$CXX`` or the
+``compiler=`` argument):
+
+* Linux / macOS: ``g++``, ``clang++``, ``c++``
+* Windows: ``g++`` / ``clang++`` (MinGW-w64 or LLVM), then MSVC ``cl.exe``
+  (run from a Developer prompt so ``cl`` is on PATH)
+
+The compiled library lands next to this module (``_lofop_ops.so`` on
+Unix, ``_lofop_ops.dll`` on Windows), falling back to ``~/.cache/lofop`` when
+the package directory is read-only, and is picked up automatically next run.
+:func:`backend` reports which implementation is active.
 """
 
 from __future__ import annotations
 
 import ctypes
 import os
+import shutil
 import subprocess
-import sysconfig
+import sys
+import tempfile
 from pathlib import Path
 
 from lofop.core.exceptions import LofopError
@@ -26,6 +36,7 @@ from lofop.core.logging import get_logger
 
 _LIB_STEM = "_lofop_ops"
 _SOURCE = Path(__file__).resolve().parent.parent / "csrc" / "box_ops.cpp"
+_IS_WINDOWS = sys.platform.startswith("win")
 
 logger = get_logger(__name__)
 _loaded: ctypes.CDLL | None = None
@@ -33,15 +44,60 @@ _load_attempted = False
 
 
 def _lib_suffix() -> str:
-    return sysconfig.get_config_var("SHLIB_SUFFIX") or ".so"
+    """Loadable-library suffix for ctypes on this platform."""
+    return ".dll" if _IS_WINDOWS else ".so"
 
 
 def _candidate_paths() -> list[Path]:
     cache_dir = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "lofop"
+    suffix = _lib_suffix()
     return [
-        Path(__file__).resolve().parent / f"{_LIB_STEM}{_lib_suffix()}",
-        cache_dir / f"{_LIB_STEM}{_lib_suffix()}",
+        Path(__file__).resolve().parent / f"{_LIB_STEM}{suffix}",
+        cache_dir / f"{_LIB_STEM}{suffix}",
     ]
+
+
+def _compiler_candidates(explicit: str | None) -> list[str]:
+    """Ordered list of compiler binaries to try (only those on PATH)."""
+    if explicit:
+        return [explicit]
+    env = os.environ.get("CXX")
+    if env:
+        return [env]
+    if _IS_WINDOWS:
+        preference = ["g++", "clang++", "cl"]
+    else:
+        preference = ["g++", "clang++", "c++"]
+    return [name for name in preference if shutil.which(name)] or preference
+
+
+def _build_command(compiler: str, source: Path, target: Path) -> tuple[list[str], Path | None]:
+    """Build the compile command for a toolchain.
+
+    Returns the argv plus an optional working directory (MSVC scatters
+    intermediate .obj/.lib files into cwd, so it runs in a temp dir).
+    """
+    # Separator-agnostic basename so a Windows "C:\\VS\\cl.exe" path is
+    # recognized even when parsed on a POSIX host (and vice versa).
+    base = compiler.replace("\\", "/").rsplit("/", 1)[-1].lower()
+    name = base[:-4] if base.endswith(".exe") else base
+    if name == "cl":  # MSVC
+        workdir = Path(tempfile.mkdtemp(prefix="lofop_build_"))
+        cmd = [
+            compiler, "/nologo", "/O2", "/std:c++17", "/EHsc", "/LD",
+            str(source), f"/Fe:{target}", f"/Fo:{workdir}\\",
+        ]
+        return cmd, workdir
+    # GNU/Clang-style front end (g++, clang++, c++, MinGW g++).
+    cmd = [compiler, "-O3", "-std=c++17", "-shared"]
+    if _IS_WINDOWS:
+        # MinGW: statically link the runtimes so the DLL has no libgcc/
+        # libstdc++ load-time dependency.
+        cmd += ["-static-libgcc", "-static-libstdc++"]
+    else:
+        cmd.append("-fPIC")
+    cmd += [str(source), "-o", str(target)]
+    return cmd, None
 
 
 def build_native(*, force: bool = False, compiler: str | None = None) -> Path:
@@ -49,39 +105,44 @@ def build_native(*, force: bool = False, compiler: str | None = None) -> Path:
 
     Args:
         force: Rebuild even if a library already exists.
-        compiler: C++ compiler binary; defaults to ``$CXX`` or ``g++``.
+        compiler: Compiler binary to use. Defaults to ``$CXX`` or the first
+            available of the platform's preferred compilers.
 
     Raises:
-        LofopError: If no compiler is available or compilation fails.
+        LofopError: If no compiler is available or every attempt fails. The
+            pure Python ops keep working regardless -- building is optional.
     """
     existing = find_library()
     if existing is not None and not force:
         return existing
-    compiler = compiler or os.environ.get("CXX", "g++")
-    last_error: Exception | None = None
-    for target in _candidate_paths():
-        target.parent.mkdir(parents=True, exist_ok=True)
-        cmd = [
-            compiler, "-O3", "-std=c++17", "-shared", "-fPIC",
-            str(_SOURCE), "-o", str(target),
-        ]
-        try:
-            subprocess.run(cmd, check=True, capture_output=True, text=True)
-        except FileNotFoundError as exc:
-            raise LofopError(
-                "No C++ compiler found; install g++/clang++ or set CXX",
-                context={"compiler": compiler},
-            ) from exc
-        except (subprocess.CalledProcessError, OSError) as exc:
-            last_error = exc
+
+    candidates = _compiler_candidates(compiler)
+    errors: list[str] = []
+    for binary in candidates:
+        if shutil.which(binary) is None and compiler is None and not os.environ.get("CXX"):
             continue
-        logger.info("Built native ops library at %s", target)
-        _reset_cache()
-        return target
-    stderr = getattr(last_error, "stderr", "")
+        for target in _candidate_paths():
+            target.parent.mkdir(parents=True, exist_ok=True)
+            cmd, workdir = _build_command(binary, _SOURCE, target)
+            try:
+                subprocess.run(cmd, check=True, capture_output=True, text=True, cwd=workdir)
+            except FileNotFoundError:
+                errors.append(f"{binary}: not found")
+                break  # try next compiler, not next path
+            except (subprocess.CalledProcessError, OSError) as exc:
+                errors.append(f"{binary}: {getattr(exc, 'stderr', exc)}")
+                continue
+            finally:
+                if workdir is not None:
+                    shutil.rmtree(workdir, ignore_errors=True)
+            logger.info("Built native ops library at %s (via %s)", target, binary)
+            _reset_cache()
+            return target
+
     raise LofopError(
-        f"Failed to build native ops library: {last_error}",
-        context={"source": str(_SOURCE), "stderr": stderr},
+        "Could not build the native ops library; pure Python ops remain available. "
+        "Install a C++ toolchain (g++/clang++, or MSVC on Windows) or set CXX.",
+        context={"tried": candidates, "errors": errors},
     )
 
 
@@ -127,6 +188,11 @@ def load_native() -> ctypes.CDLL | None:
     _loaded = lib
     logger.debug("Loaded native ops library from %s", path)
     return lib
+
+
+def backend() -> str:
+    """Return the active ops backend: ``"native"`` (C++) or ``"python"``."""
+    return "native" if load_native() is not None else "python"
 
 
 def _reset_cache() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,10 @@ deploy = [
     "onnx>=1.15",
     "onnxruntime>=1.17",
 ]
+tensorrt = [
+    "tensorrt>=8.6",
+    "numpy>=1.23",
+]
 
 [project.urls]
 Homepage = "https://github.com/tedo001/LOFOP"

--- a/tests/deploy/test_tensorrt_export.py
+++ b/tests/deploy/test_tensorrt_export.py
@@ -1,0 +1,69 @@
+"""Tests for TensorRT export.
+
+TensorRT and a CUDA GPU are not available in CI, so these tests verify the
+parts that must work without them: the module imports, the ONNX intermediate
+is produced, argument validation fires, and the missing-TensorRT path raises
+a clear, actionable error rather than an opaque ImportError.
+"""
+
+import importlib.util
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from lofop.core.exceptions import LofopError  # noqa: E402
+from lofop.deploy import build_engine_from_onnx, export_tensorrt  # noqa: E402
+from lofop.models import ApexHead, DeltaFusion, LofopDetect, RidgeNet  # noqa: E402
+
+HAVE_TENSORRT = importlib.util.find_spec("tensorrt") is not None
+IMAGE_SIZE = 64
+
+
+def tiny_model():
+    backbone = RidgeNet(widths=(16, 32, 64, 128), depths=(1, 1, 1, 1))
+    neck = DeltaFusion(in_channels=backbone.out_channels, width=32)
+    head = ApexHead(num_classes=3, width=32, num_convs=1)
+    return LofopDetect(backbone, neck, head).eval()
+
+
+class TestArgumentValidation:
+    def test_int8_requires_calibration(self, tmp_path):
+        with pytest.raises(LofopError, match="calibration"):
+            export_tensorrt(
+                tiny_model(), tmp_path / "m.engine", image_size=IMAGE_SIZE,
+                int8=True, calibration_inputs=None,
+            )
+
+    def test_build_from_missing_onnx(self, tmp_path):
+        if not HAVE_TENSORRT:
+            pytest.skip("tensorrt not installed")
+        with pytest.raises(LofopError, match="not found"):
+            build_engine_from_onnx(tmp_path / "nope.onnx", tmp_path / "m.engine")
+
+
+@pytest.mark.skipif(HAVE_TENSORRT, reason="exercises the no-TensorRT path")
+class TestWithoutTensorRT:
+    def test_export_produces_onnx_then_fails_clearly(self, tmp_path):
+        engine = tmp_path / "model.engine"
+        with pytest.raises(LofopError, match="TensorRT is not installed"):
+            export_tensorrt(
+                tiny_model(), engine, image_size=IMAGE_SIZE, keep_onnx=True,
+                onnx_path=tmp_path / "model.onnx",
+            )
+        # The ONNX stage runs before the GPU stage, so the intermediate exists
+        # and is reusable even though the engine build could not proceed.
+        assert (tmp_path / "model.onnx").is_file()
+
+    def test_build_engine_reports_missing_dependency(self, tmp_path):
+        onnx = tmp_path / "m.onnx"
+        onnx.write_bytes(b"not a real onnx")  # never parsed; import fails first
+        with pytest.raises(LofopError, match="TensorRT is not installed"):
+            build_engine_from_onnx(onnx, tmp_path / "m.engine")
+
+
+@pytest.mark.skipif(not HAVE_TENSORRT, reason="requires TensorRT + CUDA GPU")
+class TestWithTensorRT:
+    def test_fp32_engine_builds(self, tmp_path):
+        engine = export_tensorrt(tiny_model(), tmp_path / "m.engine", image_size=IMAGE_SIZE)
+        assert engine.is_file() and engine.stat().st_size > 0

--- a/tests/ops/test_native_backend.py
+++ b/tests/ops/test_native_backend.py
@@ -1,0 +1,71 @@
+"""Tests for cross-platform native-ops building and backend reporting."""
+
+import shutil
+
+import pytest
+
+from lofop.ops import backend, nms
+from lofop.ops.native import _build_command, _compiler_candidates
+
+HAVE_GNU = shutil.which("g++") or shutil.which("clang++")
+
+
+class TestBackendReporting:
+    def test_backend_is_one_of_two(self):
+        assert backend() in ("native", "python")
+
+    def test_python_path_always_available(self):
+        # Regardless of backend, native=False must work everywhere.
+        assert nms([[0, 0, 10, 10], [1, 1, 11, 11]], [0.9, 0.8],
+                   iou_threshold=0.5, native=False) == [0]
+
+    @pytest.mark.skipif(not HAVE_GNU, reason="no g++/clang++ available")
+    def test_native_matches_python_when_built(self):
+        from lofop.ops import build_native
+        from lofop.ops.native import _reset_cache
+
+        build_native()
+        _reset_cache()
+        assert backend() == "native"
+        boxes = [[0, 0, 10, 10], [1, 1, 11, 11], [50, 50, 60, 60]]
+        scores = [0.9, 0.8, 0.7]
+        assert nms(boxes, scores, native=True) == nms(boxes, scores, native=False)
+
+
+class TestCompilerSelection:
+    def test_explicit_compiler_wins(self):
+        assert _compiler_candidates("my-cxx") == ["my-cxx"]
+
+    def test_env_cxx_used(self, monkeypatch):
+        monkeypatch.setenv("CXX", "envcc")
+        assert _compiler_candidates(None) == ["envcc"]
+
+    def test_default_candidates_nonempty(self, monkeypatch):
+        monkeypatch.delenv("CXX", raising=False)
+        assert _compiler_candidates(None)
+
+
+class TestBuildCommands:
+    def test_gnu_command_shape(self, tmp_path):
+        cmd, workdir = _build_command("g++", tmp_path / "src.cpp", tmp_path / "out.so")
+        assert cmd[0] == "g++"
+        assert "-std=c++17" in cmd and "-shared" in cmd
+        assert workdir is None
+
+    def test_msvc_command_uses_temp_workdir(self, tmp_path):
+        cmd, workdir = _build_command("cl", tmp_path / "src.cpp", tmp_path / "out.dll")
+        assert cmd[0] == "cl"
+        assert "/LD" in cmd and any(a.startswith("/Fe:") for a in cmd)
+        assert workdir is not None and workdir.exists()
+        import shutil as _sh
+        _sh.rmtree(workdir, ignore_errors=True)
+
+    def test_msvc_detected_by_stem(self, tmp_path):
+        # A full path to cl.exe must still route to the MSVC branch.
+        cmd, workdir = _build_command(
+            r"C:\VS\cl.exe", tmp_path / "s.cpp", tmp_path / "o.dll"
+        )
+        assert "/LD" in cmd
+        if workdir:
+            import shutil as _sh
+            _sh.rmtree(workdir, ignore_errors=True)


### PR DESCRIPTION
## What this adds

Two portability/deployment improvements you asked for: the box ops work in **both C++ and pure Python on every OS** (including Windows), and detectors can now export to **TensorRT**.

### Cross-platform native ops
- The C++ NMS/IoU builder now auto-selects a toolchain per platform: `g++`/`clang++`/`c++` on Linux/macOS, and `g++`/`clang++` (MinGW/LLVM) or **MSVC `cl.exe`** on Windows — with the right per-toolchain flags and library suffix (`.so`/`.dll`). This closes the gap your Windows session hit (`No C++ compiler found`).
- The **pure-Python implementation still runs everywhere** and is the automatic fallback, so a compiler is never required — the C++ path is purely an accelerator. `lofop.ops.backend()` reports which one is live (`"native"` or `"python"`).

### TensorRT export
- `lofop/deploy/tensorrt_export.py` builds a serialized `.engine` from the **same verified ONNX graph** (model → ONNX → engine), so ONNX Runtime and TensorRT share one graph and one post-processing routine.
- FP16 is a single flag (`--fp16`); INT8 takes `calibration_inputs` through a minimal entropy calibrator.
- CLI: `lofop export --format tensorrt --fp16 -o model.engine`.

## Design note for review

TensorRT and a CUDA GPU are needed **only for the engine-build step**. The module imports without them, the ONNX intermediate is always produced first, and a missing `tensorrt` package raises a clear actionable error instead of an opaque `ImportError`. That's why the TensorRT tests can run in CI (they exercise the no-GPU path) with the actual engine build skipped.

## How it was tested

12 new tests — **196 passed, 2 skipped** (the skipped two are the GPU-only engine build):
- backend reporting, python-path-always-works, native/python parity when built
- compiler selection + per-toolchain command shapes, including a full `C:\VS\cl.exe` path routing to MSVC
- INT8-without-calibration validation, and the no-TensorRT path producing the ONNX intermediate then failing clearly

```
python -m pytest tests/            # 196 passed, 2 skipped
ruff check lofop tests benchmarks examples
```

Docs: `docs/deploy.md` covers both TensorRT export and native-ops portability; README and architecture roadmap updated; new `tensorrt` extra in pyproject.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TZJqK6XdEG25TKRWSk4Q6w)_