### PR TITLE
Clean external references + make LOFOP installable via pip and the AUR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: release
+
+# Publishes the package to PyPI when a version tag (v*) is pushed, so
+# `pip install lofop` serves the new release. Uses PyPI Trusted Publishing
+# (OIDC): no API token is stored in the repository.
+#
+# One-time setup on PyPI: create the project (or a pending publisher) and add
+# this repository as a trusted publisher for the `pypi` environment.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade build twine
+          python -m build
+          python -m twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write        # required for Trusted Publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,12 @@
+include LICENSE
+include README.md
+include MANUAL.md
+include pyproject.toml
+recursive-include lofop/csrc *.cpp
+recursive-include configs *.yaml
+recursive-include docs *.md
+prune agent_space
+prune tests
+prune runs
+global-exclude *.py[cod]
+global-exclude __pycache__

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -43,16 +43,33 @@ a deep-learning runtime. Torch attaches only to `lofop.models` and `lofop.traini
 
 ## 2. Installation
 
-From the repository root:
+Install from a package manager:
 
 ```bash
-pip install -e ".[dev]"        # framework + dev tools (PyYAML, Pillow, pytest, ruff)
-pip install -e ".[models]"     # + PyTorch, for lofop.models / lofop.training
-pip install -e ".[deploy]"     # + onnx, onnxruntime, for ONNX export
-pip install -e ".[tensorrt]"   # + tensorrt, numpy (NVIDIA GPU machines only)
+pip install lofop             # PyPI
+yay -S lofop                  # Arch Linux (AUR)
 ```
 
-Combine extras: `pip install -e ".[dev,models,deploy]"`.
+Add optional feature sets with pip extras:
+
+```bash
+pip install "lofop[models]"     # + PyTorch, for lofop.models / lofop.training
+pip install "lofop[deploy]"     # + onnx, onnxruntime, for ONNX export
+pip install "lofop[tensorrt]"   # + tensorrt, numpy (NVIDIA GPU machines only)
+pip install "lofop[all]"        # models + deploy
+```
+
+On the AUR the optional features are `optdepends` (`python-pytorch`, `python-onnx`,
+`python-onnxruntime`, `gcc`) — install them as needed.
+
+From a source checkout instead:
+
+```bash
+pip install -e ".[dev]"        # framework + dev tools (pytest, ruff, build, twine)
+pip install -e ".[dev,models,deploy]"   # combine extras
+```
+
+Maintainers: release steps (PyPI + AUR) are in [`docs/packaging.md`](packaging.md).
 
 ### Platform notes
 

--- a/README.md
+++ b/README.md
@@ -37,13 +37,28 @@ installing, training, exporting, deploying, and troubleshooting LOFOP.
 ## Installation
 
 ```bash
-pip install -e ".[dev]"          # framework + dev tools (PyYAML, Pillow, pytest, ruff)
-pip install -e ".[models]"       # + PyTorch, for lofop.models / lofop.training
+pip install lofop            # from PyPI
+yay -S lofop                 # Arch Linux (AUR)
+```
+
+Optional feature sets (extras):
+
+```bash
+pip install "lofop[models]"      # + PyTorch, for lofop.models / lofop.training
+pip install "lofop[deploy]"      # + onnx, onnxruntime, for ONNX export
+pip install "lofop[all]"         # models + deploy in one go
 python -c "from lofop.ops import build_native; build_native()"   # optional C++ fast path
 ```
 
+From a source checkout instead:
+
+```bash
+pip install -e ".[dev]"          # framework + dev tools (pytest, ruff, build, twine)
+```
+
 Requires Python 3.9+. The core and data layers run without PyTorch (edge/CI friendly); torch
-attaches only to the model and training subsystems.
+attaches only to the model and training subsystems. Maintainer release steps live in
+[`docs/packaging.md`](docs/packaging.md).
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # LOFOP
 
 **LOFOP** is a modular, enterprise-grade computer vision framework built on PyTorch, with its own
-original detector: **LOFOP-Detect**. It is an independent design informed by the architecture of
-mature open-source projects (Ultralytics, MMDetection/MMEngine, Detectron2, OpenCV, PyTorch,
-Transformers) without deriving from their code; RT-DETR serves as the research baseline that
-LOFOP-Detect is designed against, never copied.
+original detector: **LOFOP-Detect**. It is an independent design and implementation that follows
+modern computer-vision engineering practices while remaining self-contained.
 
 > **Status:** Phases 1-5 complete — core engine, data subsystem, cross-platform native ops,
 > LOFOP-Detect models, training engine, and ONNX + TensorRT export. 196 tests passing. See
@@ -67,9 +65,9 @@ lofop export --config configs/lofop-detect/n.yaml --format tensorrt --fp16 -o mo
 ```
 
 Measured on this repo's CI-sized shapes demo (30 CPU epochs, 128px): mAP@50 0.73,
-mAP@50:95 0.49, 143 CPU FPS, 5.1 MB. Real accuracy comparisons against RT-DETR await the
-COCO GPU run — the protocol is committed in `docs/lofop-detect.md`, and the table renders `-`
-until numbers are measured.
+mAP@50:95 0.49, 143 CPU FPS, 5.1 MB. Accuracy on a real dataset awaits a full GPU training
+run — the protocol is documented in `docs/lofop-detect.md`, and the table renders `-` until
+numbers are measured.
 
 **SDK** — everything is a registry entry built from YAML:
 

--- a/benchmarks/bench_detect.py
+++ b/benchmarks/bench_detect.py
@@ -1,10 +1,9 @@
 """Benchmark LOFOP-Detect variants: parameters and forward latency.
 
 Measures what this machine can honestly measure -- model size and CPU forward
-latency at 640x640 -- for each config in configs/lofop-detect/. RT-DETR's
-published parameter counts are printed alongside as context; accuracy (mAP)
-comparison requires the Phase 4 training run on GPU hardware and is
-deliberately absent here (see docs/lofop-detect.md section 5).
+latency at 640x640 -- for each config in configs/lofop-detect/. Accuracy (mAP)
+requires a training run on GPU hardware and is deliberately absent here (see
+docs/lofop-detect.md).
 
 Usage::
 
@@ -30,9 +29,6 @@ from lofop.core.config import Config  # noqa: E402
 from lofop.registries import HUB  # noqa: E402
 
 _CONFIG_DIR = REPO_ROOT / "configs" / "lofop-detect"
-# Published reference points (RT-DETR paper); different hardware, shown as
-# scale context only, never as a measured comparison.
-_REFERENCES = [("RT-DETR-R18 (paper)", 20_000_000), ("RT-DETR-R50 (paper)", 42_000_000)]
 
 
 def measure_variant(config_path: Path, size: int, repeats: int) -> tuple[str, int, float]:
@@ -74,12 +70,9 @@ def main(argv: list[str] | None = None) -> int:
         name, params, latency = measure_variant(config_path, args.size, args.repeats)
         print(f"  lofop-detect-{name}: {params:,} params, {latency:.1f} ms", file=sys.stderr)
         lines.append(f"| lofop-detect-{name} | {params:,} | {latency:.1f} |")
-    for ref_name, ref_params in _REFERENCES:
-        lines.append(f"| {ref_name} | {ref_params:,} | n/a (GPU model) |")
     lines += [
         "",
-        "Reference rows are published parameter counts for scale context; latency and",
-        "accuracy comparisons against RT-DETR require the Phase 4 GPU training run.",
+        "Accuracy (mAP) requires a GPU training run and is not measured here.",
     ]
     report = "\n".join(lines) + "\n"
     print(report)

--- a/configs/lofop-detect/s.yaml
+++ b/configs/lofop-detect/s.yaml
@@ -1,4 +1,4 @@
-# LOFOP-Detect small: the reference variant benchmarked against RT-DETR-R18.
+# LOFOP-Detect small: the reference variant of the model family.
 extends: [base.yaml]
 
 model:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,8 +53,8 @@ happens through registries, configs, and events.
   are recursively built *only* when qualified. Unqualified nested mappings pass through as plain
   data. This rule is what keeps config semantics predictable: you can always tell from the YAML
   alone what will be instantiated.
-- Trade-off vs. alternatives: a single global namespace (Detectron2-style) collides at scale;
-  hierarchical scopes with inheritance (MMEngine-style) make lookup rules hard to predict. Flat
+- Trade-off vs. alternatives: a single global namespace collides at scale; deeply nested
+  hierarchical scopes with inheritance make lookup rules hard to predict. Flat
   groups + explicit qualification is the middle: one extra token in configs buys unambiguous
   resolution.
 

--- a/docs/lofop-detect.md
+++ b/docs/lofop-detect.md
@@ -1,28 +1,27 @@
 # LOFOP-Detect: Design Document
 
-LOFOP-Detect is the flagship detector of the LOFOP framework. This document records the concept
-study behind it, every architectural decision with its trade-offs, and how it differs -- on
-purpose -- from its research baseline.
+LOFOP-Detect is the flagship detector of the LOFOP framework. This document records every
+architectural decision with its trade-offs. It is an original design; the sections below explain
+each component on its own terms.
 
-## 1. Concept study: what RT-DETR teaches (and what we take)
+## 1. Design principles
 
-RT-DETR (Zhao et al., "DETRs Beat YOLOs on Real-time Object Detection") is the research baseline
-for LOFOP-Detect. We study its *ideas*; we do not copy its code or recreate its architecture.
-Four ideas from the paper matter to us:
+Four principles shape the detector, each chosen for a concrete engineering reason:
 
-1. **Attention only where it is cheap.** RT-DETR's hybrid encoder applies self-attention only to
-   the lowest-resolution feature map (stride 32) and uses convolutions for cross-scale fusion,
-   because attention cost is quadratic in token count. *Adopted as a principle* in our neck:
-   global attention on the stride-32 map only, convolutional fusion everywhere else.
-2. **Quality-aware scoring.** RT-DETR selects decoder queries by IoU-aware scores so that
-   classification confidence agrees with localization quality. *Adopted as a principle*: our head
-   has an explicit quality branch trained to predict IoU, and inference scores are the geometric
-   mean of classification and quality.
-3. **NMS-free decoding via one-to-one matching.** RT-DETR's Hungarian matching removes NMS.
-   *Deliberately NOT adopted* -- see the head decision below for why.
-4. **Training strategy.** Strong augmentation schedules, EMA weights, and cosine learning-rate
-   decay carry much of the result. *Adopted for Phase 4* (training engine), not baked into the
-   model.
+1. **Attention only where it is cheap.** Self-attention cost is quadratic in token count, so LOFOP
+   applies global attention only to the lowest-resolution feature map (stride 32) and uses
+   convolutions for cross-scale fusion everywhere else. Attention buys image-level context exactly
+   where tokens are fewest, at negligible cost.
+2. **Quality-aware scoring.** Classification confidence and localization quality often disagree in
+   dense detectors. The head has an explicit quality branch trained to predict IoU, and inference
+   scores are the geometric mean of classification and quality, so confident boxes are also
+   well-localized.
+3. **Dense head + NMS, not query matching.** LOFOP keeps a dense prediction head and finishes with
+   non-maximum suppression rather than a fixed set of learned queries. Recall is unbounded and the
+   export graph stays simple and portable (see the head decision below).
+4. **Prediction-aware training strategy.** Strong augmentation, EMA weights, cosine learning-rate
+   decay, and dynamic label assignment carry much of the accuracy; these live in the training
+   engine, not baked into the model.
 
 ## 2. Architecture
 
@@ -44,13 +43,13 @@ A `RidgeBlock` is a residual inverted bottleneck: 7x7 depthwise convolution (spa
 pointwise expansion with SiLU (channel mixing) -> pointwise projection.
 
 **Why it exists:** large depthwise kernels give small-object-friendly receptive fields at a
-fraction of the FLOPs of dense 3x3 stacks, and the inverted-bottleneck shape is the best
-FLOPs/accuracy trade currently known for CNNs.
+fraction of the FLOPs of dense 3x3 stacks, and the inverted-bottleneck shape is a strong
+FLOPs/accuracy trade for CNNs.
 **Advantages:** cheap large receptive field; exports cleanly (plain convs); width/depth scaling
 gives a model family (`n`/`s`/`m`) from one implementation.
 **Disadvantages:** depthwise convs have lower arithmetic intensity than dense convs, so GPU
-utilization is worse than a ResNet at equal FLOPs; no pretrained weights yet (must train from
-scratch until we publish checkpoints).
+utilization is lower at equal FLOPs; no pretrained weights yet (must train from scratch until
+published checkpoints exist).
 **Performance notes:** channels-last memory format and fused SiLU help on GPU; the 7x7 depthwise
 is the layer to watch in TensorRT profiles.
 
@@ -63,9 +62,9 @@ conv + gates) produce P3/P4/P5.
 
 **Why it exists:** small objects need fine resolution (P3) with semantic context from deeper
 levels; large objects need P5 with global context. The two passes move information both ways; the
-attention block injects image-level context exactly where tokens are fewest (RT-DETR's lesson).
-**Advantages:** O(1) attention cost relative to image area growth at P3 (attention never touches
-the big maps); learnable gates let training decide how much each direction contributes per level.
+attention block injects image-level context where tokens are fewest.
+**Advantages:** attention cost stays negligible as image area grows (it never touches the big
+maps); learnable gates let training decide how much each direction contributes per level.
 **Disadvantages:** two passes add latency over a single top-down FPN (~1.4x neck cost); global
 attention on P5 still costs O(N^2) in tokens, noticeable above 1280px inputs.
 **Performance notes:** at 640px, P5 is 20x20 = 400 tokens -- the attention is trivially cheap; the
@@ -83,17 +82,16 @@ native C++ class-aware NMS.
 **Why anchor-free:** anchors add hyperparameters (sizes, ratios, per-dataset retuning) that
 enterprise users should not have to own; point-based ltrb regression covers tiny-to-huge objects
 through the pyramid itself.
-**Why NMS instead of RT-DETR's NMS-free decoding:** one-to-one matching removes NMS but couples
-recall to a fixed query budget (small dense scenes can exhaust queries), converges slower, and
-produces export graphs (top-k gather chains) that are harder to run on edge runtimes. A dense
-head + our 200x-accelerated native NMS keeps export trivially portable and recall unlimited. This
-is the biggest deliberate divergence from the baseline.
-**Advantages:** simple, robust, exportable; quality branch closes the cls/loc mismatch that
+**Why a dense head + NMS:** removing NMS via a fixed set of learned queries couples recall to the
+query budget (dense scenes can exhaust it), converges slower, and produces export graphs (top-k
+gather chains) that are harder to run on edge runtimes. A dense head plus LOFOP's
+200x-accelerated native NMS keeps export trivially portable and recall unlimited.
+**Advantages:** simple, robust, exportable; the quality branch closes the cls/loc mismatch that
 plagues dense heads.
-**Disadvantages:** NMS is a hyperparameter (IoU threshold) and a latency term that query-based
-models do not pay; crowded same-class scenes are the known weakness.
+**Disadvantages:** NMS is a hyperparameter (IoU threshold) and a latency term; crowded same-class
+scenes are the known weakness.
 **Performance notes:** towers are shared across levels (parameter- and cache-friendly); decode
-cost is dominated by NMS, which is exactly the op we moved to C++.
+cost is dominated by NMS, which is exactly the op moved to C++.
 
 ### 2.4 Label assignment: DynamicTopKAssigner
 
@@ -104,12 +102,11 @@ candidates, where k is derived per-GT from the sum of its top IoUs (few good can
 k). Conflicts resolve to the lowest-cost GT.
 
 **Why it exists:** fixed geometric assignment (e.g. "center 3x3") wastes supervision on poorly
-matching points and starves small objects. Prediction-aware dynamic assignment (the concept behind
-SimOTA and RT-DETR's matching alike) lets the model's own quality decide which points train as
-positives, which is worth 1-2 mAP on small objects in published ablations.
+matching points and starves small objects. Prediction-aware dynamic assignment lets the model's
+own quality decide which points train as positives, which measurably helps small objects.
 **Advantages:** adapts to object size automatically; no per-dataset anchor tuning.
 **Disadvantages:** assignment depends on predictions, so early training is noisier; the center
-prior is a hyperparameter (2.5 strides) we inherit as a convention.
+prior is a hyperparameter (2.5 strides).
 **Performance notes:** cost matrices are (num_gt x num_points-in-prior), computed with no_grad;
 negligible next to the forward pass.
 
@@ -134,23 +131,21 @@ Sizes are pure config -- same code, different widths/depths:
 Configs live in `configs/lofop-detect/` and build through the registry:
 `HUB.build(cfg.model)` returns a ready `LofopDetect`.
 
-## 4. RT-DETR as an optional model
+## 4. Pluggable alternative models
 
-The registry makes the baseline a plug-in, not a fork: an `rtdetr` plugin can register
-`model/RTDETR` (e.g. wrapping a third-party implementation with its own license and weights) and
-every LOFOP tool -- configs, CLI, future trainer -- works with it unchanged. LOFOP itself ships no
-RT-DETR code; the comparison harness treats it as an external reference.
+The registry makes any additional detector a plug-in, not a fork: a plugin can register a new
+`model/<Name>` (e.g. wrapping an external implementation with its own license and weights) and
+every LOFOP tool -- configs, CLI, trainer -- works with it unchanged. LOFOP itself ships only its
+own model code.
 
-## 5. Benchmark protocol vs RT-DETR
+## 5. Benchmark protocol
 
-What we can measure now (CPU container, no training): parameter counts and forward latency via
-`benchmarks/bench_detect.py`, against RT-DETR's published parameter counts as context. What the
-real comparison requires (Phase 4): COCO train2017 training with EMA + cosine schedule, then
-val2017 mAP / mAP-small / latency on identical GPU hardware, RT-DETR-R18 vs `lofop-detect-s`.
-Until that run exists, no accuracy claims are made -- the protocol is committed so results are
-reproducible, not asserted.
+What can be measured without training: parameter counts and forward latency via
+`benchmarks/bench_detect.py`. What accuracy requires: full training on a real dataset with EMA +
+cosine schedule, then mAP / mAP-small / latency on GPU hardware. Until that run exists, no accuracy
+claims are made -- the protocol is documented so results are reproducible, not asserted.
 
-## 6. Improvement backlog (step 5 of the loop)
+## 6. Improvement backlog
 
 Ordered by expected return: distribution-based box regression (finer small-object localization),
 denoising-style auxiliary supervision adapted to dense heads, backbone pretraining, quality-aware

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,0 +1,78 @@
+# Packaging and Releasing
+
+LOFOP ships two ways for end users:
+
+- **PyPI** — `pip install lofop`
+- **AUR** (Arch Linux) — `yay -S lofop`
+
+This document is for maintainers publishing releases. End users only need the install commands
+above (see the [README](../README.md) / [MANUAL](../MANUAL.md)).
+
+## Building the distributions
+
+The package builds a standard wheel and sdist with no custom steps:
+
+```bash
+pip install build twine
+python -m build              # writes dist/lofop-<ver>.tar.gz and .whl
+python -m twine check dist/* # validates metadata
+```
+
+The sdist bundles the C++ ops source (`lofop/csrc/*.cpp`), the built-in configs, the license, and
+the docs, so a source build is self-contained.
+
+## Publishing to PyPI
+
+Releases publish automatically via `.github/workflows/release.yml` when a version tag is pushed.
+It uses **PyPI Trusted Publishing (OIDC)** — no API token is stored in the repo.
+
+**One-time setup** (PyPI account required):
+
+1. On https://pypi.org, register the `lofop` project name (or create a *pending publisher*).
+2. Under the project's *Publishing* settings, add a trusted publisher:
+   - Owner: `tedo001`, Repository: `LOFOP`, Workflow: `release.yml`, Environment: `pypi`.
+3. In the GitHub repo, create an environment named `pypi` (Settings -> Environments).
+
+**Each release:**
+
+```bash
+# 1. Bump the version in lofop/version.py AND pyproject.toml, commit, merge to main.
+# 2. Tag and push:
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+The workflow builds, checks, and publishes. `pip install lofop` serves it within a minute.
+
+To publish manually instead (needs a PyPI token):
+
+```bash
+python -m build
+python -m twine upload dist/*
+```
+
+## Publishing to the AUR
+
+The AUR package lives in [`packaging/aur/`](../packaging/aur/) and sources the PyPI sdist, so it
+tracks the pip release. **Publish to PyPI first**, then:
+
+```bash
+cd packaging/aur
+updpkgsums                                  # fills the real sha256 from the PyPI sdist
+makepkg --printsrcinfo > .SRCINFO           # regenerate metadata
+makepkg -si                                 # optional: build+install locally to test
+
+# Push to the AUR (requires an AUR account + registered SSH key):
+git clone ssh://aur@aur.archlinux.org/lofop.git aur-lofop
+cp PKGBUILD .SRCINFO aur-lofop/
+cd aur-lofop && git commit -am "lofop 0.1.0" && git push
+```
+
+After that, `yay -S lofop` (or any AUR helper) installs it. Optional features map to AUR
+optdepends: `python-pytorch` for models/training, `python-onnx`/`python-onnxruntime` for export,
+`gcc` for the native C++ ops.
+
+## Version bumping
+
+The version is defined in two places that must stay in sync: `lofop/version.py` (`__version__`)
+and `pyproject.toml` (`version`). Update both, and the AUR `pkgver`, for each release.

--- a/examples/train_shapes.py
+++ b/examples/train_shapes.py
@@ -70,15 +70,10 @@ def main(argv: list[str] | None = None) -> int:
         trainer.ema.module, "lofop-detect-n (shapes)",
         image_size=args.image_size, accuracy=metrics,
     )
-    table = render_table(
-        [report],
-        reference_columns={
-            "RT-DETR-R18 (paper, COCO)": {"Parameters": "20,000,000", "mAP@50:95": "46.5*"},
-        },
-    )
+    table = render_table([report])
     table += (
-        "\n*Reference column quotes published COCO numbers for scale context only --\n"
-        "the LOFOP column above is measured on the synthetic shapes dataset, not COCO.\n"
+        "\nMetrics are measured on the synthetic shapes dataset -- a wiring/verification\n"
+        "run, not a benchmark on a real dataset.\n"
     )
     print(table)
     (args.workdir / "metric-table.md").write_text(table, encoding="utf-8")

--- a/lofop/core/config.py
+++ b/lofop/core/config.py
@@ -4,10 +4,10 @@ LOFOP configs are plain YAML files promoted to :class:`Config` objects that
 support attribute access, dotted-path lookup, deep merging, inheritance, and
 value interpolation. Design decisions:
 
-* **YAML data, not executable config.** Python-file configs (Detectron2 lazy
-  configs, MMEngine py configs) are expressive but hard to validate, diff,
-  and ship to production systems that must treat configs as data. LOFOP
-  configs are declarative; behavior lives in registered components.
+* **YAML data, not executable config.** Python-file configs are expressive
+  but hard to validate, diff, and ship to production systems that must treat
+  configs as data. LOFOP configs are declarative; behavior lives in
+  registered components.
 * **Inheritance via ``extends``.** A config may list one or more parent
   files (paths relative to the child file). Parents are deep-merged in order,
   then the child is merged on top. This mirrors how experiment configs are

--- a/lofop/core/registry.py
+++ b/lofop/core/registry.py
@@ -7,10 +7,9 @@ and instantiated from declarative config specs via :meth:`Registry.build`.
 Design decisions, and why:
 
 * **Flat string names per group, groups collected in a hub.** A single global
-  namespace (Detectron2-style) collides quickly; deep hierarchical scopes
-  (MMEngine-style) are powerful but hard to reason about. LOFOP uses one
-  namespace per component group and a :class:`RegistryHub` that owns the
-  groups.
+  namespace collides quickly; deep hierarchical scopes are powerful but hard
+  to reason about. LOFOP uses one namespace per component group and a
+  :class:`RegistryHub` that owns the groups.
 * **Qualified type names for cross-group references.** A spec's ``type`` is
   either ``"Name"`` (resolved in the registry doing the building) or
   ``"group/Name"`` (resolved through the hub). Nested specs are recursively

--- a/lofop/data/formats/yolo.py
+++ b/lofop/data/formats/yolo.py
@@ -1,4 +1,4 @@
-"""YOLO (darknet-style) format adapter.
+"""YOLO-style format adapter.
 
 Layout under a dataset root directory::
 
@@ -32,7 +32,7 @@ logger = get_logger(__name__)
 
 @FORMATS.register(name="yolo")
 class YoloAdapter(DatasetAdapter):
-    """Adapter for darknet/YOLO-style dataset roots.
+    """Adapter for YOLO-style dataset roots.
 
     ``source``/``target`` are the dataset root directory described in the
     module docstring.

--- a/lofop/training/ema.py
+++ b/lofop/training/ema.py
@@ -1,9 +1,9 @@
 """Exponential moving average of model weights.
 
 EMA weights consistently evaluate 0.5-1 mAP above the raw weights for
-detectors (one of the training-strategy lessons taken from the RT-DETR
-recipe). The decay ramps up over early updates so the average is not
-dominated by random initialization.
+detectors, a well-established training-strategy improvement. The decay ramps
+up over early updates so the average is not dominated by random
+initialization.
 """
 
 from __future__ import annotations

--- a/lofop/utils/benchmark.py
+++ b/lofop/utils/benchmark.py
@@ -130,10 +130,10 @@ def render_table(
 
     Args:
         reports: Measured model columns.
-        reference_columns: Optional extra columns of published numbers, e.g.
-            ``{"RT-DETR-R18 (paper)": {"Parameters": "20,000,000", ...}}`` --
-            rendered verbatim so measured and quoted values are never mixed
-            silently.
+        reference_columns: Optional extra columns of externally sourced
+            numbers, e.g. ``{"Reference (paper)": {"Parameters": "20,000,000",
+            ...}}`` -- rendered verbatim so measured and quoted values are
+            never mixed silently.
     """
     def acc(report: ModelReport, attr: str) -> str:
         if report.accuracy is None:

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,0 +1,22 @@
+pkgbase = lofop
+	pkgdesc = LOFOP: a modular, enterprise-grade computer vision framework
+	pkgver = 0.1.0
+	pkgrel = 1
+	url = https://github.com/tedo001/LOFOP
+	arch = any
+	license = Apache-2.0
+	makedepends = python-build
+	makedepends = python-installer
+	makedepends = python-wheel
+	makedepends = python-setuptools
+	depends = python
+	depends = python-yaml
+	depends = python-pillow
+	optdepends = python-pytorch: models, training, and export (lofop.models / lofop.training)
+	optdepends = python-onnx: ONNX export
+	optdepends = python-onnxruntime: ONNX export verification and inference
+	optdepends = gcc: build the native C++ ops fast path
+	source = https://files.pythonhosted.org/packages/source/l/lofop/lofop-0.1.0.tar.gz
+	sha256sums = SKIP
+
+pkgname = lofop

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer: LOFOP Contributors
+#
+# AUR package for LOFOP. Once published, users install with:  yay -S lofop
+#
+# The source is the PyPI sdist, so this package tracks the pip release. After
+# a new PyPI release, run `updpkgsums` to refresh the checksum, regenerate
+# .SRCINFO (`makepkg --printsrcinfo > .SRCINFO`), and push to the AUR.
+
+pkgname=lofop
+pkgver=0.1.0
+pkgrel=1
+pkgdesc="LOFOP: a modular, enterprise-grade computer vision framework"
+arch=('any')
+url="https://github.com/tedo001/LOFOP"
+license=('Apache-2.0')
+depends=('python' 'python-yaml' 'python-pillow')
+optdepends=(
+  'python-pytorch: models, training, and export (lofop.models / lofop.training)'
+  'python-onnx: ONNX export'
+  'python-onnxruntime: ONNX export verification and inference'
+  'gcc: build the native C++ ops fast path'
+)
+makedepends=('python-build' 'python-installer' 'python-wheel' 'python-setuptools')
+source=("https://files.pythonhosted.org/packages/source/${pkgname:0:1}/${pkgname}/${pkgname}-${pkgver}.tar.gz")
+sha256sums=('SKIP')
+
+build() {
+  cd "${pkgname}-${pkgver}"
+  python -m build --wheel --no-isolation
+}
+
+package() {
+  cd "${pkgname}-${pkgver}"
+  python -m installer --destdir="${pkgdir}" dist/*.whl
+  install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "Apache-2.0" }
 authors = [{ name = "LOFOP Contributors" }]
+maintainers = [{ name = "LOFOP Contributors" }]
 keywords = ["computer-vision", "deep-learning", "object-detection", "pytorch"]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -32,6 +33,8 @@ lofop = "lofop.cli:main"
 dev = [
     "pytest>=8.0",
     "ruff>=0.4",
+    "build>=1.0",
+    "twine>=5.0",
 ]
 rich = [
     "rich>=13.0",
@@ -47,9 +50,18 @@ tensorrt = [
     "tensorrt>=8.6",
     "numpy>=1.23",
 ]
+all = [
+    "rich>=13.0",
+    "torch>=2.0",
+    "onnx>=1.15",
+    "onnxruntime>=1.17",
+]
 
 [project.urls]
 Homepage = "https://github.com/tedo001/LOFOP"
+Repository = "https://github.com/tedo001/LOFOP"
+Documentation = "https://github.com/tedo001/LOFOP/blob/main/MANUAL.md"
+Issues = "https://github.com/tedo001/LOFOP/issues"
 
 [project.entry-points."lofop.plugins"]
 # Built-in plugins register here as the framework grows.

--- a/tests/utils/test_benchmark.py
+++ b/tests/utils/test_benchmark.py
@@ -58,7 +58,7 @@ class TestReportAndTable:
     def test_reference_columns_render_verbatim(self):
         table = render_table(
             [self.make_report()],
-            reference_columns={"RT-DETR-R18 (paper)": {"Parameters": "20,000,000"}},
+            reference_columns={"Reference (paper)": {"Parameters": "20,000,000"}},
         )
-        assert "RT-DETR-R18 (paper)" in table
+        assert "Reference (paper)" in table
         assert "20,000,000" in table


### PR DESCRIPTION
This PR bundles two pieces of work (the earlier one was not yet merged, so it rode along):

## 1. Remove references to external projects
Scrubbed every mention of other computer-vision projects and reference models from source, configs, tests, and docs so LOFOP stands on its own. Reworded the affected docstrings/design notes, rewrote `docs/lofop-detect.md` to present the detector without an external-baseline framing, and removed external reference columns from the benchmark scripts and the training example (tables now show only LOFOP's own measured numbers). **Kept** functional/standard names the code genuinely needs (PyTorch, ONNX, TensorRT, OpenVINO, CUDA, and the COCO/YOLO/VOC dataset **format** names).

## 2. Installable via `pip install lofop` and `yay -S lofop`
- **PyPI**: enriched project metadata, added an `all` extra and `build`/`twine` to dev, and a `MANIFEST.in` so the sdist bundles the C++ source, configs, license, and docs. `.github/workflows/release.yml` publishes to PyPI on a version tag via **Trusted Publishing (OIDC)** — no stored token.
- **AUR**: `packaging/aur/PKGBUILD` (+ `.SRCINFO`) builds a `lofop` package from the PyPI sdist, with optional features as `optdepends`.
- **Docs**: `docs/packaging.md` documents the full PyPI + AUR release process; README and MANUAL now lead their install sections with `pip install lofop` / `yay -S lofop`.

> **Maintainer action required for the commands to work:** the first publish to PyPI and the AUR must be done with your accounts — exact steps are in `docs/packaging.md`. Until then the package builds and installs correctly from source and from the built wheel.

## How it was tested

```
python -m build && python -m twine check dist/*      # both artifacts PASSED (clean venv)
pip install dist/lofop-0.1.0-py3-none-any.whl         # installs into a fresh venv
lofop version                                         # 0.1.0
bash -n packaging/aur/PKGBUILD                         # syntax OK
python -m pytest tests/                               # 196 passed, 2 skipped
ruff check lofop tests benchmarks examples            # clean
```