### PR TITLE
Add GitHub Actions CI (lint + tests + build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: ci
+
+# Runs lint and the full test suite on every push to the main branches and on
+# every pull request, so nothing broken can be merged and the package stays
+# releasable at all times.
+
+on:
+  push:
+    branches: [main, tedo]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install ruff
+        run: python -m pip install "ruff>=0.4"
+      - name: Lint
+        run: ruff check lofop tests benchmarks examples
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install CPU PyTorch
+        run: python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+      - name: Install LOFOP with test extras
+        run: python -m pip install -e ".[dev,models,deploy]"
+      - name: Build native C++ ops
+        run: python -c "from lofop.ops import build_native, backend; build_native(); print('ops backend:', backend())"
+      - name: Run tests
+        run: python -m pytest tests/ -q
+
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Build and check distributions
+        run: |
+          python -m pip install --upgrade build twine
+          python -m build
+          python -m twine check dist/*

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # LOFOP
 
+[![ci](https://github.com/tedo001/LOFOP/actions/workflows/ci.yml/badge.svg)](https://github.com/tedo001/LOFOP/actions/workflows/ci.yml)
+[![Python](https://img.shields.io/badge/python-3.9%2B-blue.svg)](https://www.python.org/)
+[![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](LICENSE)
+
 **LOFOP** is a modular, enterprise-grade computer vision framework built on PyTorch, with its own
 original detector: **LOFOP-Detect**. It is an independent design and implementation that follows
 modern computer-vision engineering practices while remaining self-contained.
@@ -135,9 +139,13 @@ python benchmarks/bench_ops.py                     # C++ vs Python ops speedups
 python benchmarks/bench_detect.py                  # detector params + latency
 ```
 
+Every push and pull request runs the full test suite (Python 3.9/3.11/3.12, native C++ ops
+built) and lint via GitHub Actions ([`.github/workflows/ci.yml`](.github/workflows/ci.yml)), and a
+distribution build check, so `main` stays releasable.
+
 ## Roadmap
 
-Next phases: inference sources (video/RTSP/webcam), OpenVINO engines, REST serving, and CI.
+Next phases: inference sources (video/RTSP/webcam), OpenVINO engines, and REST serving.
 The full subsystem map with per-phase status lives in [`docs/architecture.md`](docs/architecture.md).
 
 ## License

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,6 +36,7 @@ and the build order. Module-level documents (e.g. [`core-engine.md`](core-engine
 | 6 | `lofop.deploy` | ONNX + TensorRT export and torch-free post-processing done; OpenVINO/REST planned | In progress (see docs/deploy.md) |
 | 7 | `lofop.cli` | `lofop` CLI (`dataset` tools done; `train`/`predict`/`export` planned) | In progress |
 | 8 | `lofop.utils` | Model benchmarking (metric table, FLOPs, FPS, size) done; visualization planned | In progress |
+| -- | CI / packaging | GitHub Actions CI (lint + tests + build) and PyPI/AUR packaging | **Done** |
 | -- | `lofop.ops` | Cross-platform native C++ box ops (IoU, NMS) with Python fallback; MSVC/MinGW/g++/clang | **Done** |
 
 Each phase lands with its own tests and docs before the next begins. Dependencies point downward


### PR DESCRIPTION
## What this adds

A CI quality gate so `main` stays releasable and nothing broken can be merged — the foundation before publishing the package.

`.github/workflows/ci.yml` runs on every push to `main`/`tedo` and every PR, with three jobs:

- **lint** — `ruff` over `lofop`, `tests`, `benchmarks`, `examples`.
- **test** — the full suite on **Python 3.9 / 3.11 / 3.12**, with CPU PyTorch and the `deploy` extra installed and the **native C++ ops compiled**, so the torch and native-parity tests actually run instead of skipping.
- **package** — builds the sdist + wheel and runs `twine check`, catching a broken distribution before release.

Concurrency cancels superseded runs on the same ref. README gets a CI status badge and a short note; the architecture roadmap marks CI/packaging done.

## How it was tested

Reproduced each CI step locally on this branch:

```
ruff check lofop tests benchmarks examples                                   # clean
python -c "from lofop.ops import build_native, backend; build_native(); print(backend())"  # native
python -m pytest tests/                                                      # 196 passed, 2 skipped
python -m build && python -m twine check dist/*                               # PASSED
```

Both workflow files (`ci.yml` and the existing `release.yml`) validated as parseable YAML.

> Note: the CI badge will show "no runs" until this merges and the workflow first executes on `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TZJqK6XdEG25TKRWSk4Q6w)_