### PR TITLE
Release 1.1.0: version bump and co-author credit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-15
+
 ### Added
 - CLI: `lofop predict` (image inference), `lofop evaluate` (dataset metrics),
   and `lofop doctor` (environment and backend diagnostics).
@@ -41,5 +43,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Python SDK (`Detector`) and the `lofop` CLI.
 - Packaging for PyPI (wheel/sdist) and AUR; CI and release workflows.
 
-[Unreleased]: https://github.com/tedo001/LOFOP/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/tedo001/LOFOP/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/tedo001/LOFOP/compare/v0.1.0...v1.1.0
 [0.1.0]: https://github.com/tedo001/LOFOP/releases/tag/v0.1.0

--- a/lofop/version.py
+++ b/lofop/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the LOFOP package version."""
 
-__version__ = "0.0.8"
+__version__ = "1.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,15 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lofop"
-version = "0.0.8"
+version = "1.1.0"
 description = "LOFOP: a modular, enterprise-grade computer vision framework."
 readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "Apache-2.0" }
-authors = [{ name = "DURGAMANI SASIKUMAR" }]
+authors = [
+    { name = "DURGAMANI SASIKUMAR" },
+    { name = "Nishanandhini A. (Assistant Professor)" },
+]
 maintainers = [{ name = "LOFOP Contributors" }]
 keywords = ["computer-vision", "deep-learning", "object-detection", "pytorch"]
 classifiers = [


### PR DESCRIPTION
Bump the package version to 1.1.0 (pyproject.toml + lofop/version.py, kept in sync for the CI check), add Nishanandhini A. (Assistant Professor) as a package co-author, and move the unreleased changelog entries under a dated 1.1.0 heading.

## Summary

What does this change do, and why?

## Changes

- 

## Test plan

Commands you ran and their results:

```
ruff check lofop tests benchmarks examples
python -m pytest tests/ -q
```

## Checklist

- [ ] Tests added or updated for the change
- [ ] `ruff check` is clean
- [ ] `pytest` passes locally
- [ ] Docs updated (`MANUAL.md` / `docs/`) if user-facing
- [ ] `CHANGELOG.md` updated under "Unreleased"
- [ ] Public APIs remain backward compatible (or the break is justified above)
