### PR TITLE
Bump version to 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [1.1.1] - 2026-07-15
+## [1.1.2] - 2026-07-15
 
 ### Added
 - CLI: `lofop predict` (image inference), `lofop evaluate` (dataset metrics),
@@ -43,6 +43,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Python SDK (`Detector`) and the `lofop` CLI.
 - Packaging for PyPI (wheel/sdist) and AUR; CI and release workflows.
 
-[Unreleased]: https://github.com/tedo001/LOFOP/compare/v1.1.1...HEAD
-[1.1.1]: https://github.com/tedo001/LOFOP/compare/v0.1.0...v1.1.1
+[Unreleased]: https://github.com/tedo001/LOFOP/compare/v1.1.2...HEAD
+[1.1.2]: https://github.com/tedo001/LOFOP/compare/v0.1.0...v1.1.2
 [0.1.0]: https://github.com/tedo001/LOFOP/releases/tag/v0.1.0

--- a/lofop/version.py
+++ b/lofop/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the LOFOP package version."""
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lofop"
-version = "1.1.1"
+version = "1.1.2"
 description = "LOFOP: a modular, enterprise-grade computer vision framework."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
pyproject.toml, lofop/version.py, and the changelog heading move together so the CI version-sync check stays green.

## Summary

What does this change do, and why?

## Changes

- 

## Test plan

Commands you ran and their results:

```
ruff check lofop tests benchmarks examples
python -m pytest tests/ -q
```

## Checklist

- [ ] Tests added or updated for the change
- [ ] `ruff check` is clean
- [ ] `pytest` passes locally
- [ ] Docs updated (`MANUAL.md` / `docs/`) if user-facing
- [ ] `CHANGELOG.md` updated under "Unreleased"
- [ ] Public APIs remain backward compatible (or the break is justified above)
