### PR TITLE
Cpp inference sdk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,25 @@ jobs:
       - name: Run tests with coverage (fails under the configured floor)
         run: python -m pytest tests/ --cov --cov-report=term-missing
 
+  # The C++ SDK builds and tests on every platform LOFOP supports, with no
+  # ONNX Runtime: the pipeline it implements (preprocessing, decoding,
+  # suppression, coordinate mapping) is exercised through a stub engine, so a
+  # regression is caught without a model or a GPU in CI.
+  cpp:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure
+        run: cmake -S cpp -B build -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: cmake --build build --config Release
+      - name: Test
+        run: ctest --test-dir build --build-config Release --output-on-failure
+
   package:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Ops: optional CUDA tier (`build_native(cuda=True)`, needs nvcc) for
   pairwise IoU and dense decode on NVIDIA GPUs; `backend()` now reports
   `cuda`/`native`/`python`, always falling back cleanly.
+- Inference: selectable duplicate-removal via `nms_mode` on every model and
+  `Detector` -- `"greedy"` (default, unchanged), `"soft"` (Soft-NMS score
+  decay), or `"free"` (NMS-free 3x3 peak selection: pure tensor math, no
+  suppression loop).
 
 ### Changed
 - ONNX export raises a clear error for segmentation/pose models (their

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [1.2.0] - 2026-07-28
+## [1.2.1] - 2026-07-31
 
 ### Added
 - Instance segmentation: `lofop-detect-{n,s,ex}-seg` variants
@@ -87,8 +87,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Python SDK (`Detector`) and the `lofop` CLI.
 - Packaging for PyPI (wheel/sdist) and AUR; CI and release workflows.
 
-[Unreleased]: https://github.com/tedo001/LOFOP/compare/v1.2.0...HEAD
-[1.2.0]: https://github.com/tedo001/LOFOP/compare/v1.1.3...v1.2.0
+[Unreleased]: https://github.com/tedo001/LOFOP/compare/v1.2.1...HEAD
+[1.2.1]: https://github.com/tedo001/LOFOP/compare/v1.1.3...v1.2.1
 [1.1.3]: https://github.com/tedo001/LOFOP/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/tedo001/LOFOP/compare/v0.1.0...v1.1.2
 [0.1.0]: https://github.com/tedo001/LOFOP/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- C++ inference SDK (`cpp/`): `lofop::Detector`, `lofop::Image`,
+  `lofop::Detection`, and a pluggable `lofop::Engine` (ONNX Runtime backend
+  included), plus a flat C ABI (`lofop/lofop_c.h`) for Go/Rust/C#/Java
+  bindings. Builds with CMake and any C++17 compiler; ONNX Runtime is a
+  compile-time option, so the library and its tests build without it.
+- Torch-free Python inference runtime (`lofop.runtime`): `Detector`,
+  `Detection`, and `Image` mirroring the C++ types, running an exported
+  `model.onnx` through ONNX Runtime with no PyTorch import.
+- Shared image preprocessing (`lofop/csrc/preprocess.cpp`,
+  `lofop.ops.letterbox` / `unletterbox_boxes`): aspect-preserving resize with
+  padding and its exact inverse, defined once in C++ and bound by both
+  runtimes, with a pure Python reference for compiler-free installs. Parity
+  between kernel and reference is asserted to float32 epsilon in CI.
+- CI: the C++ SDK is built and tested on Linux, Windows, and macOS.
+
+### Changed
+- The native ops library now compiles from multiple translation units
+  (`box_ops.cpp` + `preprocess.cpp`); previously built libraries still load,
+  as new symbols are bound behind `hasattr` guards.
+
 ## [1.2.1] - 2026-07-31
 
 ### Added

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -4,7 +4,7 @@ A complete, practical guide to installing, running, training, exporting, and dep
 its flagship detector **LOFOP-Detect**. This is the hands-on manual; for architecture and design
 rationale see [`docs/architecture.md`](docs/architecture.md) and the per-module docs it links.
 
-- **Version:** 1.2.0
+- **Version:** 1.2.1
 - **Python:** 3.9+
 - **Platforms:** Linux, macOS, Windows
 
@@ -85,7 +85,7 @@ Maintainers: release steps (PyPI + AUR) are in [`docs/packaging.md`](packaging.m
 ## 3. Verify your install
 
 ```bash
-lofop version                  # prints 1.2.0
+lofop version                  # prints 1.2.1
 python -m pytest               # runs the test suite (316 passed, 3 skipped without GPU/TensorBoard)
 ```
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -86,7 +86,7 @@ Maintainers: release steps (PyPI + AUR) are in [`docs/packaging.md`](packaging.m
 
 ```bash
 lofop version                  # prints 1.2.0
-python -m pytest               # runs the test suite (308 passed, 3 skipped without GPU/TensorBoard)
+python -m pytest               # runs the test suite (316 passed, 3 skipped without GPU/TensorBoard)
 ```
 
 Then run the self-contained demo — it generates its own data, trains LOFOP-Detect end to end, and
@@ -301,6 +301,20 @@ automatically from the dataset's annotations. Note: horizontal-flip
 augmentation is disabled for pose training (flipping would need left/right
 keypoint swapping), and `strong_augment` is not yet supported for seg/pose.
 ONNX export currently covers detection models only.
+
+### Inference NMS modes
+
+Every model (and `Detector(..., nms_mode=...)`) supports three
+duplicate-removal strategies at inference:
+
+| Mode | What it does | When to use |
+|---|---|---|
+| `greedy` (default) | classic class-aware NMS | general use; unchanged behavior |
+| `soft` | decays overlapping scores (gaussian, `soft_nms_sigma`) instead of dropping | crowded scenes with touching objects |
+| `free` | NMS-free: keeps only 3x3 local score peaks -- pure tensor math, no suppression loop | latency-critical paths; large candidate counts |
+
+Config keys: `model.nms_mode`, `model.soft_nms_sigma`. At runtime:
+`det.model.nms_mode = "soft"`.
 
 ### Training config
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ installing, training, exporting, deploying, and troubleshooting LOFOP.
   TensorRT engine (`--format tensorrt --fp16`) via that same ONNX;
   `postprocess_dense` finishes inference torch-free with the C++ NMS, so serving hosts need only a
   runtime + the LOFOP core. Details: [`docs/deploy.md`](docs/deploy.md).
+- **C++ SDK + torch-free Python runtime** — the same detector runs from either language on one
+  exported model: `lofop::Detector model("model.onnx")` in C++ (no Python in the artifact) and
+  `from lofop.runtime import Detector` in Python (no torch). Both bind the *same* kernels
+  (letterbox, dense decode, class-aware NMS), so they cannot drift; a C ABI
+  (`lofop/lofop_c.h`) carries the same pipeline to Go/Rust/C#/Java. Details:
+  [`docs/cpp-sdk.md`](docs/cpp-sdk.md).
 - **Deployment scaffolding** — CPU / CUDA / ONNX Runtime Docker images ([`docker/`](docker/README.md)).
 
 ## Installation
@@ -129,6 +135,20 @@ for hit in det.predict("photo.jpg"):                  # boxes in original image 
 det.export("model.onnx")
 ```
 
+**Deploy in C++ or Python** — one exported model, two runtimes ([full guide](docs/cpp-sdk.md)):
+
+```cpp
+#include <lofop/lofop.hpp>                       // no Python, no PyTorch
+lofop::Detector model("model.onnx");
+for (const auto& hit : model.predict("image.ppm")) std::cout << hit.confidence;
+```
+
+```python
+from lofop.runtime import Detector               # no PyTorch
+model = Detector("model.onnx")
+results = model.predict("image.jpg")
+```
+
 Lower-level control remains fully public — registries, `Config`, `Trainer`, and the deploy
 functions are the same objects the SDK uses:
 
@@ -162,8 +182,11 @@ lofop/
   ops/ + csrc/   # native C++ IoU/NMS with Python fallback
   utils/         # model benchmarking (metric table, FLOPs, FPS)
   sdk.py         # high-level Python SDK: the Detector class (docs/sdk.md)
+  runtime/       # torch-free ONNX inference: Detector, Detection, Image
+  csrc/          # C++ kernels: box ops + shared letterbox preprocessing
   configs/       # packaged model family definitions (n, s, ex)
   cli.py         # `lofop` command: dataset / train / benchmark / export
+cpp/             # C++ inference SDK (CMake): headers, C ABI, tests, example
 configs/         # training config examples
 docker/          # CPU, CUDA, and ONNX Runtime images
 docs/            # architecture, per-module references, LOFOP-Detect design doc

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ modern computer-vision engineering practices while remaining self-contained.
 > C++ / optional CUDA), the LOFOP-Detect family (detection + segmentation + pose
 > variants), training engine (schedulers, early stopping, strong augmentation), full
 > CLI, Python SDK, and verified ONNX (fixed + dynamic shapes) / TensorRT export.
-> 308 tests passing with a coverage-gated CI. See
+> 316 tests passing with a coverage-gated CI. See
 > [`docs/architecture.md`](docs/architecture.md) for the subsystem map and
 > [`CHANGELOG.md`](CHANGELOG.md) for release history.
 
@@ -169,7 +169,7 @@ docker/          # CPU, CUDA, and ONNX Runtime images
 docs/            # architecture, per-module references, LOFOP-Detect design doc
 benchmarks/      # reusable performance measurement scripts
 examples/        # end-to-end runnable demos
-tests/           # pytest suite mirroring the package layout (308 tests)
+tests/           # pytest suite mirroring the package layout (316 tests)
 ```
 
 ## Development

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,0 +1,111 @@
+# LOFOP C++ inference SDK.
+#
+# Builds `lofop` (the C++ API plus the C ABI) from the SDK sources and the
+# same native kernels the Python package compiles, so the two runtimes cannot
+# drift apart. ONNX Runtime is optional at build time: without it everything
+# still compiles and the test suite still runs, and only loading a .onnx by
+# path is unavailable.
+#
+#   cmake -S cpp -B build
+#   cmake --build build
+#   ctest --test-dir build --output-on-failure
+#
+# With ONNX Runtime:
+#   cmake -S cpp -B build -DLOFOP_WITH_ONNXRUNTIME=ON -DONNXRUNTIME_ROOT=/path/to/onnxruntime
+
+cmake_minimum_required(VERSION 3.16)
+project(lofop VERSION 1.2.1 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+endif()
+
+option(LOFOP_WITH_ONNXRUNTIME "Enable the ONNX Runtime execution backend" OFF)
+option(LOFOP_WITH_STB_IMAGE "Decode JPEG/PNG via a vendored stb_image.h" OFF)
+option(LOFOP_BUILD_TESTS "Build the SDK test suite" ON)
+option(LOFOP_BUILD_EXAMPLES "Build the example programs" ON)
+option(BUILD_SHARED_LIBS "Build a shared library instead of static" OFF)
+
+# The kernels live with the Python package; the SDK compiles the same files
+# rather than copying them, which is what keeps both languages numerically
+# identical.
+set(LOFOP_CSRC "${CMAKE_CURRENT_SOURCE_DIR}/../lofop/csrc")
+
+add_library(lofop
+  src/image.cpp
+  src/detector.cpp
+  src/engine_onnxruntime.cpp
+  src/capi.cpp
+  "${LOFOP_CSRC}/box_ops.cpp"
+  "${LOFOP_CSRC}/preprocess.cpp"
+)
+add_library(lofop::lofop ALIAS lofop)
+
+target_include_directories(lofop PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
+if(MSVC)
+  target_compile_options(lofop PRIVATE /W4)
+else()
+  target_compile_options(lofop PRIVATE -Wall -Wextra)
+endif()
+
+if(LOFOP_WITH_ONNXRUNTIME)
+  # Accept either an ONNXRUNTIME_ROOT pointing at an extracted release, or
+  # headers and library already on the default search paths.
+  find_path(ONNXRUNTIME_INCLUDE_DIR onnxruntime_cxx_api.h
+    HINTS ${ONNXRUNTIME_ROOT} ENV ONNXRUNTIME_ROOT
+    PATH_SUFFIXES include include/onnxruntime include/onnxruntime/core/session
+  )
+  find_library(ONNXRUNTIME_LIBRARY onnxruntime
+    HINTS ${ONNXRUNTIME_ROOT} ENV ONNXRUNTIME_ROOT
+    PATH_SUFFIXES lib lib64
+  )
+  if(NOT ONNXRUNTIME_INCLUDE_DIR OR NOT ONNXRUNTIME_LIBRARY)
+    message(FATAL_ERROR
+      "LOFOP_WITH_ONNXRUNTIME=ON but ONNX Runtime was not found. "
+      "Download a release from https://github.com/microsoft/onnxruntime/releases "
+      "and pass -DONNXRUNTIME_ROOT=/path/to/extracted/onnxruntime.")
+  endif()
+  target_compile_definitions(lofop PUBLIC LOFOP_WITH_ONNXRUNTIME)
+  target_include_directories(lofop PRIVATE ${ONNXRUNTIME_INCLUDE_DIR})
+  target_link_libraries(lofop PUBLIC ${ONNXRUNTIME_LIBRARY})
+  message(STATUS "LOFOP: ONNX Runtime backend enabled (${ONNXRUNTIME_LIBRARY})")
+else()
+  message(STATUS "LOFOP: building without ONNX Runtime; supply your own Engine to run models")
+endif()
+
+if(LOFOP_WITH_STB_IMAGE)
+  find_path(STB_IMAGE_INCLUDE_DIR stb_image.h HINTS ${STB_IMAGE_ROOT} ENV STB_IMAGE_ROOT)
+  if(NOT STB_IMAGE_INCLUDE_DIR)
+    message(FATAL_ERROR "LOFOP_WITH_STB_IMAGE=ON but stb_image.h was not found; "
+                        "pass -DSTB_IMAGE_ROOT=/path/containing/stb_image.h")
+  endif()
+  target_compile_definitions(lofop PRIVATE LOFOP_WITH_STB_IMAGE)
+  target_include_directories(lofop PRIVATE ${STB_IMAGE_INCLUDE_DIR})
+endif()
+
+if(LOFOP_BUILD_TESTS)
+  enable_testing()
+  add_executable(lofop_tests tests/test_lofop.cpp)
+  target_link_libraries(lofop_tests PRIVATE lofop)
+  add_test(NAME lofop_tests COMMAND lofop_tests)
+endif()
+
+if(LOFOP_BUILD_EXAMPLES)
+  add_executable(detect_image examples/detect_image.cpp)
+  target_link_libraries(detect_image PRIVATE lofop)
+endif()
+
+include(GNUInstallDirs)
+install(TARGETS lofop EXPORT lofopTargets
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(EXPORT lofopTargets NAMESPACE lofop:: DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/lofop)

--- a/cpp/examples/detect_image.cpp
+++ b/cpp/examples/detect_image.cpp
@@ -1,0 +1,52 @@
+// Minimal LOFOP C++ SDK example: load a model, detect, print.
+//
+// Build (from the repository root):
+//   cmake -S cpp -B build -DLOFOP_WITH_ONNXRUNTIME=ON -DONNXRUNTIME_ROOT=/path/to/onnxruntime
+//   cmake --build build
+//   ./build/detect_image model.onnx image.ppm
+//
+// Produce model.onnx from a trained checkpoint with:
+//   lofop export --config lofop/configs/lofop-detect/s.yaml \
+//                --checkpoint runs/train/best.pt -o model.onnx
+
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <string>
+
+#include "lofop/lofop.hpp"
+
+int main(int argc, char** argv) {
+    if (argc < 3) {
+        std::cerr << "usage: detect_image <model.onnx> <image> [score_threshold]\n";
+        return 2;
+    }
+    const std::string model_path = argv[1];
+    const std::string image_path = argv[2];
+
+    lofop::Options options;
+    if (argc > 3) {
+        options.score_threshold = std::strtof(argv[3], nullptr);
+    }
+    // Names are optional; without them detections report "class_<index>".
+    options.class_names = {};
+
+    try {
+        lofop::Detector detector(model_path, options);
+        std::cout << "model " << model_path << " | input " << detector.input_size()
+                  << "px | backend " << detector.backend() << '\n';
+
+        const auto detections = detector.predict(image_path);
+        std::cout << detections.size() << " detection(s) in " << image_path << '\n';
+        std::cout << std::fixed << std::setprecision(1);
+        for (const auto& hit : detections) {
+            std::cout << "  " << hit.name << "  " << std::setprecision(3) << hit.confidence
+                      << std::setprecision(1) << "  [" << hit.x1 << ", " << hit.y1 << ", "
+                      << hit.x2 << ", " << hit.y2 << "]\n";
+        }
+    } catch (const lofop::Error& exc) {
+        std::cerr << "error: " << exc.what() << '\n';
+        return 1;
+    }
+    return 0;
+}

--- a/cpp/include/lofop/lofop.hpp
+++ b/cpp/include/lofop/lofop.hpp
@@ -1,0 +1,168 @@
+// LOFOP C++ inference SDK.
+//
+// Runs a LOFOP detector exported to ONNX from a C++ process, with no Python
+// and no PyTorch anywhere in the deployed artifact:
+//
+//     #include <lofop/lofop.hpp>
+//
+//     lofop::Detector model("model.onnx");
+//     for (const auto& hit : model.predict("image.ppm")) {
+//         std::cout << hit.name << ' ' << hit.confidence << '\n';
+//     }
+//
+// The pipeline is deliberately thin, because most of it already exists:
+// preprocessing comes from lofop/csrc/preprocess.cpp, dense decoding and
+// class-aware NMS from lofop/csrc/box_ops.cpp -- the same kernels the Python
+// runtime calls through ctypes -- and graph execution is delegated to ONNX
+// Runtime rather than reimplemented. Given one model.onnx, this SDK and
+// lofop.runtime return the same detections.
+//
+// Execution sits behind the Engine interface, so ONNX Runtime is a
+// compile-time option (LOFOP_WITH_ONNXRUNTIME): the library, its tests, and
+// everything except the graph call build with nothing but a C++17 compiler.
+
+#ifndef LOFOP_LOFOP_HPP
+#define LOFOP_LOFOP_HPP
+
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace lofop {
+
+// Version of the SDK, kept in step with the Python package.
+constexpr const char* kVersion = "1.2.1";
+
+// Thrown for every failure this SDK reports: missing files, unreadable
+// images, malformed models, inference errors.
+class Error : public std::runtime_error {
+public:
+    explicit Error(const std::string& message) : std::runtime_error(message) {}
+};
+
+// An 8-bit image in row-major HWC layout -- the same shape lofop.runtime.Image
+// holds in Python, so both runtimes accept identical pixel buffers.
+class Image {
+public:
+    Image() = default;
+    Image(int width, int height, int channels, std::vector<uint8_t> pixels);
+
+    // Wrap pixels you already hold (a decoded frame, a cv::Mat's data, a
+    // camera buffer). No decoding, no format assumptions.
+    static Image from_pixels(const uint8_t* pixels, int width, int height, int channels = 3);
+
+    // Read an image file. Binary PPM (P6) and PGM (P5) are supported with no
+    // dependencies; building with LOFOP_WITH_STB_IMAGE adds every format
+    // stb_image handles (JPEG, PNG, BMP, ...). Throws Error otherwise.
+    static Image load(const std::string& path);
+
+    int width() const { return width_; }
+    int height() const { return height_; }
+    int channels() const { return channels_; }
+    bool empty() const { return pixels_.empty(); }
+    const std::vector<uint8_t>& pixels() const { return pixels_; }
+
+private:
+    int width_ = 0;
+    int height_ = 0;
+    int channels_ = 0;
+    std::vector<uint8_t> pixels_;
+};
+
+// One detected object, in the source image's own pixel coordinates.
+struct Detection {
+    float x1 = 0.0f;
+    float y1 = 0.0f;
+    float x2 = 0.0f;
+    float y2 = 0.0f;
+    float confidence = 0.0f;
+    int label = 0;
+    std::string name;
+
+    float width() const { return x2 - x1; }
+    float height() const { return y2 - y1; }
+    float area() const { return width() > 0 && height() > 0 ? width() * height() : 0.0f; }
+};
+
+// Inference settings. Defaults match lofop.runtime.Detector so the two
+// runtimes agree without either side restating them.
+struct Options {
+    float score_threshold = 0.25f;
+    float nms_iou = 0.6f;
+    int max_detections = 300;
+    // Model input side length. 0 means "read it from the graph", which works
+    // for fixed-shape exports; dynamic-shape models need it set.
+    int image_size = 0;
+    // Padding fill for letterboxing, in [0, 1].
+    float pad_value = 0.447f;
+    // Class-aware Soft-NMS score decay instead of greedy suppression.
+    bool soft_nms = false;
+    float soft_sigma = 0.5f;
+    std::vector<std::string> class_names;
+};
+
+// The dense output of one forward pass: the exported graph's two tensors.
+struct DenseOutput {
+    std::vector<float> boxes;   // num_candidates * 4, xyxy in letterboxed pixels
+    std::vector<float> scores;  // num_candidates * num_classes, in [0, 1]
+    int num_candidates = 0;
+    int num_classes = 0;
+};
+
+// Graph execution, abstracted so the backend is a choice rather than a
+// dependency: ONNX Runtime today, TensorRT or OpenVINO by implementing this
+// interface, and a deterministic stub in the test suite.
+class Engine {
+public:
+    virtual ~Engine() = default;
+
+    // Run one CHW float32 image of `input_size()` per side, values in [0, 1].
+    virtual DenseOutput run(const float* nchw, std::size_t length) = 0;
+
+    // Side length this engine expects.
+    virtual int input_size() const = 0;
+
+    // Human-readable backend name, e.g. "onnxruntime".
+    virtual std::string backend() const = 0;
+};
+
+// Build an ONNX Runtime engine for a model file.
+// Throws Error when the SDK was built without LOFOP_WITH_ONNXRUNTIME.
+std::unique_ptr<Engine> make_onnxruntime_engine(const std::string& model_path, int image_size);
+
+// True when this build can load .onnx files directly.
+bool has_onnxruntime();
+
+// Detect objects in images using an exported LOFOP model.
+class Detector {
+public:
+    // Load a model by path. Requires an ONNX Runtime-enabled build.
+    explicit Detector(const std::string& model_path, Options options = {});
+
+    // Take an engine directly: custom backends, or a stub in tests.
+    explicit Detector(std::unique_ptr<Engine> engine, Options options = {});
+
+    // Detect objects; boxes come back in the image's own coordinates.
+    std::vector<Detection> predict(const Image& image) const;
+
+    // Convenience overload that loads the file first.
+    std::vector<Detection> predict(const std::string& image_path) const;
+
+    // Name for a class index, falling back to "class_<index>".
+    std::string class_name(int label) const;
+
+    int input_size() const { return engine_->input_size(); }
+    std::string backend() const { return engine_->backend(); }
+    const Options& options() const { return options_; }
+    Options& options() { return options_; }
+
+private:
+    std::unique_ptr<Engine> engine_;
+    Options options_;
+};
+
+}  // namespace lofop
+
+#endif  // LOFOP_LOFOP_HPP

--- a/cpp/include/lofop/lofop_c.h
+++ b/cpp/include/lofop/lofop_c.h
@@ -1,0 +1,91 @@
+/* LOFOP C ABI: the language-neutral inference boundary.
+ *
+ * The C++ API is the natural one for C++ callers; this header exists for
+ * everyone else. A flat C ABI is stable across compilers and standard-library
+ * versions and is the boundary Go (cgo), Rust (FFI), C# (P/Invoke), and Java
+ * (JNI/FFM) can all bind to directly -- the same reason TensorFlow ships a C
+ * API next to its C++ one.
+ *
+ * Ownership: lofop_detector_create returns a handle the caller frees with
+ * lofop_detector_free. Detection arrays returned by the predict calls are
+ * owned by the handle and stay valid until the next predict call on that
+ * handle or until it is freed.
+ *
+ * Errors: functions return a negative status and leave a message retrievable
+ * with lofop_last_error(); no exception ever crosses this boundary.
+ */
+
+#ifndef LOFOP_LOFOP_C_H
+#define LOFOP_LOFOP_C_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define LOFOP_OK 0
+#define LOFOP_ERROR (-1)
+
+/* One detection, in the source image's own pixel coordinates. */
+typedef struct {
+    float x1;
+    float y1;
+    float x2;
+    float y2;
+    float confidence;
+    int32_t label;
+} lofop_detection;
+
+/* Inference settings; zero-initialise then override what you need, or call
+ * lofop_options_default to get the same defaults the C++ and Python APIs use. */
+typedef struct {
+    float score_threshold;
+    float nms_iou;
+    int32_t max_detections;
+    int32_t image_size;  /* 0 = read from the graph */
+    float pad_value;
+    int32_t soft_nms;    /* 0 = greedy NMS, 1 = Soft-NMS */
+    float soft_sigma;
+} lofop_options;
+
+typedef struct lofop_detector lofop_detector;
+
+/* Fill `options` with LOFOP's documented defaults. */
+void lofop_options_default(lofop_options* options);
+
+/* Load a model. Returns NULL on failure; see lofop_last_error(). */
+lofop_detector* lofop_detector_create(const char* model_path, const lofop_options* options);
+
+/* Release a detector created by lofop_detector_create. Safe on NULL. */
+void lofop_detector_free(lofop_detector* detector);
+
+/* Detect objects in an image file.
+ * On success returns the detection count (>= 0) and points *out at an array
+ * owned by `detector`. Returns LOFOP_ERROR on failure. */
+int32_t lofop_detector_predict_path(lofop_detector* detector, const char* image_path,
+                                    const lofop_detection** out);
+
+/* Detect objects in a pixel buffer you already hold (row-major HWC, 8-bit,
+ * 1 or 3 channels). Same return contract as lofop_detector_predict_path. */
+int32_t lofop_detector_predict_pixels(lofop_detector* detector, const uint8_t* pixels,
+                                      int32_t width, int32_t height, int32_t channels,
+                                      const lofop_detection** out);
+
+/* Model input side length this detector runs at. */
+int32_t lofop_detector_input_size(const lofop_detector* detector);
+
+/* Message describing the most recent failure on this thread; never NULL. */
+const char* lofop_last_error(void);
+
+/* SDK version string, e.g. "1.2.1". */
+const char* lofop_version(void);
+
+/* Non-zero when this build can load .onnx files by path. */
+int32_t lofop_has_onnxruntime(void);
+
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif
+
+#endif /* LOFOP_LOFOP_C_H */

--- a/cpp/src/capi.cpp
+++ b/cpp/src/capi.cpp
@@ -1,0 +1,163 @@
+// Implementation of the LOFOP C ABI (include/lofop/lofop_c.h).
+//
+// A thin, exception-free shell over the C++ API: every entry point catches
+// everything, stores a thread-local message, and returns a status code, so no
+// exception ever unwinds across the ABI boundary into a caller that cannot
+// handle it (Go, Rust, C#, Java).
+
+#include <cstring>
+#include <exception>
+#include <memory>
+#include <new>
+#include <string>
+#include <vector>
+
+#include "lofop/lofop.hpp"
+#include "lofop/lofop_c.h"
+
+namespace {
+
+// Thread-local so concurrent callers never overwrite each other's diagnostics.
+thread_local std::string g_last_error;
+
+void set_error(const std::string& message) { g_last_error = message; }
+
+}  // namespace
+
+// Holds the detector plus the buffer backing the most recent result, which is
+// what lets the C API hand out a pointer the caller does not have to free.
+struct lofop_detector {
+    std::unique_ptr<lofop::Detector> detector;
+    std::vector<lofop_detection> results;
+};
+
+namespace {
+
+lofop::Options to_cpp_options(const lofop_options* options) {
+    lofop::Options result;
+    if (options == nullptr) {
+        return result;
+    }
+    result.score_threshold = options->score_threshold;
+    result.nms_iou = options->nms_iou;
+    result.max_detections = options->max_detections;
+    result.image_size = options->image_size;
+    result.pad_value = options->pad_value;
+    result.soft_nms = options->soft_nms != 0;
+    result.soft_sigma = options->soft_sigma;
+    return result;
+}
+
+int32_t emit(lofop_detector* handle, const std::vector<lofop::Detection>& detections,
+             const lofop_detection** out) {
+    handle->results.clear();
+    handle->results.reserve(detections.size());
+    for (const auto& detection : detections) {
+        lofop_detection item;
+        item.x1 = detection.x1;
+        item.y1 = detection.y1;
+        item.x2 = detection.x2;
+        item.y2 = detection.y2;
+        item.confidence = detection.confidence;
+        item.label = static_cast<int32_t>(detection.label);
+        handle->results.push_back(item);
+    }
+    if (out != nullptr) {
+        *out = handle->results.empty() ? nullptr : handle->results.data();
+    }
+    return static_cast<int32_t>(handle->results.size());
+}
+
+}  // namespace
+
+extern "C" {
+
+void lofop_options_default(lofop_options* options) {
+    if (options == nullptr) {
+        return;
+    }
+    const lofop::Options defaults;
+    options->score_threshold = defaults.score_threshold;
+    options->nms_iou = defaults.nms_iou;
+    options->max_detections = defaults.max_detections;
+    options->image_size = defaults.image_size;
+    options->pad_value = defaults.pad_value;
+    options->soft_nms = defaults.soft_nms ? 1 : 0;
+    options->soft_sigma = defaults.soft_sigma;
+}
+
+lofop_detector* lofop_detector_create(const char* model_path, const lofop_options* options) {
+    if (model_path == nullptr) {
+        set_error("model_path is null");
+        return nullptr;
+    }
+    try {
+        std::unique_ptr<lofop_detector> handle(new lofop_detector());
+        handle->detector.reset(new lofop::Detector(model_path, to_cpp_options(options)));
+        g_last_error.clear();
+        return handle.release();
+    } catch (const std::exception& exc) {
+        set_error(exc.what());
+        return nullptr;
+    } catch (...) {
+        set_error("unknown error while creating the detector");
+        return nullptr;
+    }
+}
+
+void lofop_detector_free(lofop_detector* detector) { delete detector; }
+
+int32_t lofop_detector_predict_path(lofop_detector* detector, const char* image_path,
+                                    const lofop_detection** out) {
+    if (detector == nullptr || image_path == nullptr) {
+        set_error("detector or image_path is null");
+        return LOFOP_ERROR;
+    }
+    try {
+        const auto detections = detector->detector->predict(std::string(image_path));
+        g_last_error.clear();
+        return emit(detector, detections, out);
+    } catch (const std::exception& exc) {
+        set_error(exc.what());
+        return LOFOP_ERROR;
+    } catch (...) {
+        set_error("unknown error during inference");
+        return LOFOP_ERROR;
+    }
+}
+
+int32_t lofop_detector_predict_pixels(lofop_detector* detector, const uint8_t* pixels,
+                                      int32_t width, int32_t height, int32_t channels,
+                                      const lofop_detection** out) {
+    if (detector == nullptr || pixels == nullptr) {
+        set_error("detector or pixels is null");
+        return LOFOP_ERROR;
+    }
+    try {
+        const lofop::Image image = lofop::Image::from_pixels(pixels, width, height, channels);
+        const auto detections = detector->detector->predict(image);
+        g_last_error.clear();
+        return emit(detector, detections, out);
+    } catch (const std::exception& exc) {
+        set_error(exc.what());
+        return LOFOP_ERROR;
+    } catch (...) {
+        set_error("unknown error during inference");
+        return LOFOP_ERROR;
+    }
+}
+
+int32_t lofop_detector_input_size(const lofop_detector* detector) {
+    if (detector == nullptr || !detector->detector) {
+        return LOFOP_ERROR;
+    }
+    return static_cast<int32_t>(detector->detector->input_size());
+}
+
+const char* lofop_last_error(void) { return g_last_error.c_str(); }
+
+const char* lofop_version(void) { return lofop::kVersion; }
+
+int32_t lofop_has_onnxruntime(void) { return lofop::has_onnxruntime() ? 1 : 0; }
+
+}  // extern "C"

--- a/cpp/src/detector.cpp
+++ b/cpp/src/detector.cpp
@@ -1,0 +1,173 @@
+// The LOFOP C++ inference pipeline: preprocess, run, decode, suppress, map back.
+//
+// Every numerical step here calls a kernel that already existed and is already
+// tested: lofop_letterbox and lofop_unletterbox_boxes from csrc/preprocess.cpp,
+// lofop_decode_dense, lofop_nms, and lofop_soft_nms from csrc/box_ops.cpp.
+// Python's lofop.runtime.Detector calls the same four functions through
+// ctypes, which is why the two runtimes agree on a shared model rather than
+// merely intending to.
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "lofop/lofop.hpp"
+
+// The native kernels, declared rather than re-included: box_ops.cpp and
+// preprocess.cpp are compiled into this library and expose a plain C ABI.
+extern "C" {
+int32_t lofop_letterbox(const uint8_t* src, int32_t sw, int32_t sh, int32_t channels,
+                        int32_t size, float pad_value, float* dst, float* meta);
+int32_t lofop_unletterbox_boxes(const float* boxes, int32_t n, const float* meta,
+                                int32_t width, int32_t height, float* out);
+int32_t lofop_decode_dense(const float* scores, int32_t n, int32_t num_classes, float threshold,
+                           int32_t* index_out, int32_t* label_out, float* score_out);
+int32_t lofop_nms(const float* boxes, const float* scores, int32_t n, float iou_threshold,
+                  int32_t max_keep, int32_t* keep_out);
+int32_t lofop_soft_nms(const float* boxes, const float* scores, int32_t n, float iou_threshold,
+                       float sigma, float score_threshold, int32_t method, int32_t max_keep,
+                       int32_t* keep_out, float* score_out);
+}
+
+namespace lofop {
+namespace {
+
+// Class-aware suppression is expressed by shifting each class into its own
+// coordinate band, so a single-class kernel never compares across classes.
+// This must stay equal to lofop.ops.boxes.CLASS_OFFSET: the two runtimes
+// would otherwise suppress differently on multi-class images.
+constexpr float kClassOffset = 1e7f;
+
+std::vector<float> shift_by_class(const std::vector<float>& boxes,
+                                  const std::vector<int32_t>& labels) {
+    std::vector<float> shifted(boxes.size());
+    for (std::size_t i = 0; i < labels.size(); ++i) {
+        const float offset = kClassOffset * static_cast<float>(labels[i]);
+        for (int c = 0; c < 4; ++c) {
+            shifted[i * 4 + c] = boxes[i * 4 + c] + offset;
+        }
+    }
+    return shifted;
+}
+
+}  // namespace
+
+Detector::Detector(const std::string& model_path, Options options)
+    : engine_(make_onnxruntime_engine(model_path, options.image_size)),
+      options_(std::move(options)) {}
+
+Detector::Detector(std::unique_ptr<Engine> engine, Options options)
+    : engine_(std::move(engine)), options_(std::move(options)) {
+    if (!engine_) {
+        throw Error("Detector received a null engine");
+    }
+}
+
+std::string Detector::class_name(int label) const {
+    if (label >= 0 && static_cast<std::size_t>(label) < options_.class_names.size()) {
+        return options_.class_names[static_cast<std::size_t>(label)];
+    }
+    return "class_" + std::to_string(label);
+}
+
+std::vector<Detection> Detector::predict(const std::string& image_path) const {
+    return predict(Image::load(image_path));
+}
+
+std::vector<Detection> Detector::predict(const Image& image) const {
+    if (image.empty()) {
+        throw Error("Detector::predict received an empty image");
+    }
+    const int size = engine_->input_size();
+    if (size <= 0) {
+        throw Error("Engine reported a non-positive input size");
+    }
+
+    // 1. Preprocess: aspect-preserving resize into a CHW float tensor.
+    std::vector<float> tensor(static_cast<std::size_t>(size) * size * 3);
+    float meta[3] = {0.0f, 0.0f, 0.0f};
+    if (lofop_letterbox(image.pixels().data(), image.width(), image.height(), image.channels(),
+                        size, options_.pad_value, tensor.data(), meta) != 0) {
+        throw Error("Preprocessing failed for the supplied image");
+    }
+
+    // 2. Execute the graph.
+    const DenseOutput dense = engine_->run(tensor.data(), tensor.size());
+    if (dense.num_candidates <= 0 || dense.num_classes <= 0) {
+        return {};
+    }
+
+    // 3. Dense decode: best class per candidate, thresholded.
+    const int32_t n = dense.num_candidates;
+    std::vector<int32_t> indices(static_cast<std::size_t>(n));
+    std::vector<int32_t> labels(static_cast<std::size_t>(n));
+    std::vector<float> scores(static_cast<std::size_t>(n));
+    const int32_t candidates =
+        lofop_decode_dense(dense.scores.data(), n, dense.num_classes, options_.score_threshold,
+                           indices.data(), labels.data(), scores.data());
+    if (candidates <= 0) {
+        return {};
+    }
+    indices.resize(static_cast<std::size_t>(candidates));
+    labels.resize(static_cast<std::size_t>(candidates));
+    scores.resize(static_cast<std::size_t>(candidates));
+
+    std::vector<float> candidate_boxes(static_cast<std::size_t>(candidates) * 4);
+    for (int32_t i = 0; i < candidates; ++i) {
+        const std::size_t source = static_cast<std::size_t>(indices[i]) * 4;
+        std::copy(dense.boxes.begin() + source, dense.boxes.begin() + source + 4,
+                  candidate_boxes.begin() + static_cast<std::size_t>(i) * 4);
+    }
+
+    // 4. Class-aware duplicate removal.
+    const std::vector<float> shifted = shift_by_class(candidate_boxes, labels);
+    std::vector<int32_t> keep(static_cast<std::size_t>(candidates));
+    std::vector<float> kept_scores(static_cast<std::size_t>(candidates));
+    int32_t kept = 0;
+    if (options_.soft_nms) {
+        kept = lofop_soft_nms(shifted.data(), scores.data(), candidates, options_.nms_iou,
+                              options_.soft_sigma, options_.score_threshold, /*method=*/0,
+                              options_.max_detections, keep.data(), kept_scores.data());
+    } else {
+        kept = lofop_nms(shifted.data(), scores.data(), candidates, options_.nms_iou,
+                         options_.max_detections, keep.data());
+        for (int32_t i = 0; i < kept; ++i) {
+            kept_scores[static_cast<std::size_t>(i)] = scores[static_cast<std::size_t>(keep[i])];
+        }
+    }
+    if (kept <= 0) {
+        return {};
+    }
+
+    // 5. Map surviving boxes back to the original image's coordinates.
+    std::vector<float> final_boxes(static_cast<std::size_t>(kept) * 4);
+    for (int32_t i = 0; i < kept; ++i) {
+        const std::size_t source = static_cast<std::size_t>(keep[i]) * 4;
+        std::copy(candidate_boxes.begin() + source, candidate_boxes.begin() + source + 4,
+                  final_boxes.begin() + static_cast<std::size_t>(i) * 4);
+    }
+    std::vector<float> mapped(final_boxes.size());
+    if (lofop_unletterbox_boxes(final_boxes.data(), kept, meta, image.width(), image.height(),
+                                mapped.data()) != 0) {
+        throw Error("Mapping boxes back to image coordinates failed");
+    }
+
+    std::vector<Detection> results;
+    results.reserve(static_cast<std::size_t>(kept));
+    for (int32_t i = 0; i < kept; ++i) {
+        Detection detection;
+        detection.x1 = mapped[static_cast<std::size_t>(i) * 4];
+        detection.y1 = mapped[static_cast<std::size_t>(i) * 4 + 1];
+        detection.x2 = mapped[static_cast<std::size_t>(i) * 4 + 2];
+        detection.y2 = mapped[static_cast<std::size_t>(i) * 4 + 3];
+        detection.confidence = kept_scores[static_cast<std::size_t>(i)];
+        detection.label = static_cast<int>(labels[static_cast<std::size_t>(keep[i])]);
+        detection.name = class_name(detection.label);
+        results.push_back(std::move(detection));
+    }
+    return results;
+}
+
+}  // namespace lofop

--- a/cpp/src/engine_onnxruntime.cpp
+++ b/cpp/src/engine_onnxruntime.cpp
@@ -1,0 +1,139 @@
+// ONNX Runtime execution backend for the LOFOP C++ SDK.
+//
+// Execution is delegated, not reimplemented. ONNX Runtime is a mature,
+// heavily optimised graph executor maintained by people who do nothing else;
+// writing convolution kernels to compete with it would cost years and lose.
+// This file is therefore thin by design -- it adapts LOFOP's Engine interface
+// to an Ort::Session and nothing more.
+//
+// The whole backend is behind LOFOP_WITH_ONNXRUNTIME. Without it the SDK still
+// builds, links, and passes its tests with any C++17 compiler; only the
+// "load a .onnx by path" constructor is unavailable, and it says so clearly.
+
+#include <string>
+#include <vector>
+
+#include "lofop/lofop.hpp"
+
+#ifdef LOFOP_WITH_ONNXRUNTIME
+
+#include <onnxruntime_cxx_api.h>
+
+#include <array>
+#include <cstddef>
+
+namespace lofop {
+namespace {
+
+class OnnxRuntimeEngine : public Engine {
+public:
+    OnnxRuntimeEngine(const std::string& model_path, int image_size)
+        : env_(ORT_LOGGING_LEVEL_WARNING, "lofop"), session_(nullptr) {
+        Ort::SessionOptions session_options;
+        session_options.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_ALL);
+        try {
+#ifdef _WIN32
+            const std::wstring wide(model_path.begin(), model_path.end());
+            session_ = Ort::Session(env_, wide.c_str(), session_options);
+#else
+            session_ = Ort::Session(env_, model_path.c_str(), session_options);
+#endif
+        } catch (const Ort::Exception& exc) {
+            throw Error("Cannot load ONNX model '" + model_path + "': " + exc.what());
+        }
+        if (session_.GetOutputCount() < 2) {
+            throw Error("Model does not expose LOFOP's dense (boxes, scores) outputs: " +
+                        model_path);
+        }
+
+        Ort::AllocatorWithDefaultOptions allocator;
+        input_name_ = session_.GetInputNameAllocated(0, allocator).get();
+        for (std::size_t i = 0; i < 2; ++i) {
+            output_names_.push_back(session_.GetOutputNameAllocated(i, allocator).get());
+        }
+        input_size_ = image_size > 0 ? image_size : infer_input_size();
+    }
+
+    DenseOutput run(const float* nchw, std::size_t length) override {
+        const std::array<int64_t, 4> shape{1, 3, input_size_, input_size_};
+        auto memory = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+        Ort::Value input = Ort::Value::CreateTensor<float>(
+            memory, const_cast<float*>(nchw), length, shape.data(), shape.size());
+
+        const char* input_names[] = {input_name_.c_str()};
+        const char* output_names[] = {output_names_[0].c_str(), output_names_[1].c_str()};
+        std::vector<Ort::Value> outputs;
+        try {
+            outputs = session_.Run(Ort::RunOptions{nullptr}, input_names, &input, 1,
+                                   output_names, 2);
+        } catch (const Ort::Exception& exc) {
+            throw Error(std::string("Inference failed: ") + exc.what());
+        }
+
+        const auto box_shape = outputs[0].GetTensorTypeAndShapeInfo().GetShape();
+        const auto score_shape = outputs[1].GetTensorTypeAndShapeInfo().GetShape();
+        if (box_shape.empty() || score_shape.empty()) {
+            throw Error("Model returned an output with no shape");
+        }
+
+        DenseOutput dense;
+        dense.num_candidates = static_cast<int>(box_shape[box_shape.size() - 2]);
+        dense.num_classes = static_cast<int>(score_shape[score_shape.size() - 1]);
+        const std::size_t box_count = static_cast<std::size_t>(dense.num_candidates) * 4;
+        const std::size_t score_count =
+            static_cast<std::size_t>(dense.num_candidates) * dense.num_classes;
+        const float* box_data = outputs[0].GetTensorData<float>();
+        const float* score_data = outputs[1].GetTensorData<float>();
+        dense.boxes.assign(box_data, box_data + box_count);
+        dense.scores.assign(score_data, score_data + score_count);
+        return dense;
+    }
+
+    int input_size() const override { return input_size_; }
+
+    std::string backend() const override { return "onnxruntime"; }
+
+private:
+    // Read the side length from a fixed-shape graph; dynamic exports carry a
+    // symbolic (negative) dimension, where 640 is LOFOP's documented default.
+    int infer_input_size() const {
+        const auto shape = session_.GetInputTypeInfo(0).GetTensorTypeAndShapeInfo().GetShape();
+        if (shape.size() == 4 && shape[2] > 0) {
+            return static_cast<int>(shape[2]);
+        }
+        return 640;
+    }
+
+    Ort::Env env_;
+    Ort::Session session_;
+    std::string input_name_;
+    std::vector<std::string> output_names_;
+    int input_size_ = 640;
+};
+
+}  // namespace
+
+std::unique_ptr<Engine> make_onnxruntime_engine(const std::string& model_path, int image_size) {
+    return std::unique_ptr<Engine>(new OnnxRuntimeEngine(model_path, image_size));
+}
+
+bool has_onnxruntime() { return true; }
+
+}  // namespace lofop
+
+#else  // LOFOP_WITH_ONNXRUNTIME
+
+namespace lofop {
+
+std::unique_ptr<Engine> make_onnxruntime_engine(const std::string& model_path, int) {
+    throw Error(
+        "This LOFOP build has no ONNX Runtime backend, so '" + model_path +
+        "' cannot be loaded by path. Rebuild with -DLOFOP_WITH_ONNXRUNTIME=ON, "
+        "or construct Detector with your own Engine implementation.");
+}
+
+bool has_onnxruntime() { return false; }
+
+}  // namespace lofop
+
+#endif  // LOFOP_WITH_ONNXRUNTIME

--- a/cpp/src/image.cpp
+++ b/cpp/src/image.cpp
@@ -1,0 +1,152 @@
+// Image construction and file loading for the LOFOP C++ SDK.
+//
+// Decoding is not LOFOP's business: production callers almost always already
+// hold pixels (a decoded video frame, a cv::Mat, a camera buffer) and should
+// use Image::from_pixels, which copies nothing but the bytes. For the cases
+// that do need a file, binary PPM/PGM is supported with no dependencies --
+// enough for tests, tooling, and pipelines that dump raw frames -- and
+// building with LOFOP_WITH_STB_IMAGE adds every format stb_image handles.
+
+#include <cctype>
+#include <cstdio>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "lofop/lofop.hpp"
+
+#ifdef LOFOP_WITH_STB_IMAGE
+#define STB_IMAGE_IMPLEMENTATION
+#include "stb_image.h"
+#endif
+
+namespace lofop {
+namespace {
+
+// Read the next whitespace-delimited token of a NetPBM header, skipping the
+// '#' comments the format allows between any two tokens.
+bool next_header_token(std::istream& stream, std::string& token) {
+    token.clear();
+    int ch = stream.get();
+    while (stream) {
+        if (std::isspace(ch) != 0) {
+            ch = stream.get();
+            continue;
+        }
+        if (ch == '#') {
+            while (stream && ch != '\n') {
+                ch = stream.get();
+            }
+            continue;
+        }
+        break;
+    }
+    while (stream && std::isspace(ch) == 0) {
+        token.push_back(static_cast<char>(ch));
+        ch = stream.get();
+    }
+    return !token.empty();
+}
+
+Image load_netpbm(const std::string& path) {
+    std::ifstream stream(path, std::ios::binary);
+    if (!stream) {
+        throw Error("Cannot open image file: " + path);
+    }
+    std::string magic;
+    if (!next_header_token(stream, magic) || (magic != "P6" && magic != "P5")) {
+        throw Error(
+            "Unsupported image format: " + path +
+            " (this build reads binary PPM/PGM; rebuild with LOFOP_WITH_STB_IMAGE "
+            "for JPEG/PNG, or decode it yourself and use Image::from_pixels)");
+    }
+    const int channels = (magic == "P6") ? 3 : 1;
+    std::string width_token;
+    std::string height_token;
+    std::string maxval_token;
+    if (!next_header_token(stream, width_token) || !next_header_token(stream, height_token) ||
+        !next_header_token(stream, maxval_token)) {
+        throw Error("Truncated image header: " + path);
+    }
+    int width = 0;
+    int height = 0;
+    int maxval = 0;
+    try {
+        width = std::stoi(width_token);
+        height = std::stoi(height_token);
+        maxval = std::stoi(maxval_token);
+    } catch (const std::exception&) {
+        throw Error("Malformed image header: " + path);
+    }
+    if (width <= 0 || height <= 0) {
+        throw Error("Image has non-positive dimensions: " + path);
+    }
+    if (maxval != 255) {
+        throw Error("Only 8-bit images are supported (maxval 255): " + path);
+    }
+    // Exactly one whitespace character separates the header from the payload.
+    const std::size_t count =
+        static_cast<std::size_t>(width) * static_cast<std::size_t>(height) * channels;
+    std::vector<uint8_t> pixels(count);
+    stream.read(reinterpret_cast<char*>(pixels.data()), static_cast<std::streamsize>(count));
+    if (static_cast<std::size_t>(stream.gcount()) != count) {
+        throw Error("Truncated image data: " + path);
+    }
+    return Image(width, height, channels, std::move(pixels));
+}
+
+}  // namespace
+
+Image::Image(int width, int height, int channels, std::vector<uint8_t> pixels)
+    : width_(width), height_(height), channels_(channels), pixels_(std::move(pixels)) {
+    if (width_ <= 0 || height_ <= 0) {
+        throw Error("Image needs positive dimensions");
+    }
+    if (channels_ != 1 && channels_ != 3) {
+        throw Error("Image supports 1 or 3 channels");
+    }
+    const std::size_t expected =
+        static_cast<std::size_t>(width_) * static_cast<std::size_t>(height_) * channels_;
+    if (pixels_.size() != expected) {
+        std::ostringstream message;
+        message << "Pixel buffer does not match the declared image size (expected " << expected
+                << ", got " << pixels_.size() << ")";
+        throw Error(message.str());
+    }
+}
+
+Image Image::from_pixels(const uint8_t* pixels, int width, int height, int channels) {
+    if (pixels == nullptr) {
+        throw Error("Image::from_pixels received a null buffer");
+    }
+    if (width <= 0 || height <= 0) {
+        throw Error("Image needs positive dimensions");
+    }
+    if (channels != 1 && channels != 3) {
+        throw Error("Image supports 1 or 3 channels");
+    }
+    const std::size_t count =
+        static_cast<std::size_t>(width) * static_cast<std::size_t>(height) * channels;
+    return Image(width, height, channels, std::vector<uint8_t>(pixels, pixels + count));
+}
+
+Image Image::load(const std::string& path) {
+#ifdef LOFOP_WITH_STB_IMAGE
+    int width = 0;
+    int height = 0;
+    int source_channels = 0;
+    uint8_t* data = stbi_load(path.c_str(), &width, &height, &source_channels, 3);
+    if (data != nullptr) {
+        const std::size_t count =
+            static_cast<std::size_t>(width) * static_cast<std::size_t>(height) * 3;
+        std::vector<uint8_t> pixels(data, data + count);
+        stbi_image_free(data);
+        return Image(width, height, 3, std::move(pixels));
+    }
+    // stb could not decode it; the NetPBM reader gives a clearer diagnostic.
+#endif
+    return load_netpbm(path);
+}
+
+}  // namespace lofop

--- a/cpp/tests/test_lofop.cpp
+++ b/cpp/tests/test_lofop.cpp
@@ -1,0 +1,260 @@
+// Tests for the LOFOP C++ SDK.
+//
+// No test framework: LOFOP's C++ builds with any C++17 compiler and no
+// dependencies, and its test suite keeps that property so `cmake --build .`
+// followed by `ctest` works on a bare machine. The harness below is twenty
+// lines and reports the same things a framework would.
+//
+// Graph execution is supplied by StubEngine, which returns fixed dense
+// outputs. That is not a shortcut around testing the real thing: it isolates
+// everything LOFOP actually implements -- preprocessing, decoding,
+// suppression, coordinate mapping -- from ONNX Runtime, which has its own test
+// suite. The numbers asserted here match tests/runtime/test_runtime.py, so
+// the two language runtimes are pinned to the same expected output.
+
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "lofop/lofop.hpp"
+#include "lofop/lofop_c.h"
+
+namespace {
+
+int g_failures = 0;
+int g_checks = 0;
+
+void check(bool condition, const std::string& what) {
+    ++g_checks;
+    if (!condition) {
+        ++g_failures;
+        std::cerr << "  FAIL: " << what << '\n';
+    }
+}
+
+void check_close(float actual, float expected, const std::string& what, float tolerance = 1e-3f) {
+    ++g_checks;
+    if (std::fabs(actual - expected) > tolerance) {
+        ++g_failures;
+        std::cerr << "  FAIL: " << what << " (expected " << expected << ", got " << actual
+                  << ")\n";
+    }
+}
+
+// Returns the same dense outputs the Python parity test feeds its stub model:
+// two overlapping class-0 boxes (the second must be suppressed), one class-1
+// box, and one candidate below the score threshold.
+class StubEngine : public lofop::Engine {
+public:
+    explicit StubEngine(int size) : size_(size) {}
+
+    lofop::DenseOutput run(const float* nchw, std::size_t length) override {
+        last_input_.assign(nchw, nchw + length);
+        lofop::DenseOutput dense;
+        dense.num_candidates = 4;
+        dense.num_classes = 3;
+        dense.boxes = {
+            10.0f, 10.0f, 30.0f, 30.0f,
+            11.0f, 11.0f, 31.0f, 31.0f,
+            40.0f, 40.0f, 60.0f, 60.0f,
+            0.0f, 0.0f, 5.0f, 5.0f,
+        };
+        dense.scores = {
+            0.9f, 0.0f, 0.0f,
+            0.8f, 0.0f, 0.0f,
+            0.0f, 0.7f, 0.0f,
+            0.0f, 0.0f, 0.1f,
+        };
+        return dense;
+    }
+
+    int input_size() const override { return size_; }
+    std::string backend() const override { return "stub"; }
+    const std::vector<float>& last_input() const { return last_input_; }
+
+private:
+    int size_;
+    std::vector<float> last_input_;
+};
+
+lofop::Options stub_options() {
+    lofop::Options options;
+    options.class_names = {"cat", "dog", "bird"};
+    return options;
+}
+
+// A 128x96 image: aspect 4:3, so letterboxing to 64 gives scale 0.5 and 8
+// pixels of padding top and bottom -- the geometry the assertions below use.
+lofop::Image make_test_image() {
+    std::vector<uint8_t> pixels(static_cast<std::size_t>(128) * 96 * 3);
+    for (std::size_t i = 0; i < pixels.size(); ++i) {
+        pixels[i] = static_cast<uint8_t>(i % 251);
+    }
+    return lofop::Image(128, 96, 3, std::move(pixels));
+}
+
+void test_image_construction() {
+    std::cout << "test_image_construction\n";
+    const lofop::Image image = make_test_image();
+    check(image.width() == 128 && image.height() == 96, "image reports its dimensions");
+    check(image.channels() == 3, "image reports its channel count");
+    check(!image.empty(), "constructed image is not empty");
+
+    bool threw = false;
+    try {
+        lofop::Image bad(4, 4, 3, std::vector<uint8_t>(10));
+    } catch (const lofop::Error&) {
+        threw = true;
+    }
+    check(threw, "mismatched pixel buffer is rejected");
+
+    threw = false;
+    try {
+        lofop::Image bad(0, 4, 3, std::vector<uint8_t>());
+    } catch (const lofop::Error&) {
+        threw = true;
+    }
+    check(threw, "non-positive dimensions are rejected");
+}
+
+void test_predict_pipeline() {
+    std::cout << "test_predict_pipeline\n";
+    auto engine = std::unique_ptr<StubEngine>(new StubEngine(64));
+    const StubEngine* observer = engine.get();
+    lofop::Detector detector(std::move(engine), stub_options());
+
+    const auto results = detector.predict(make_test_image());
+    check(results.size() == 2, "NMS suppresses the duplicate and the threshold drops the weak one");
+    if (results.size() != 2) {
+        return;
+    }
+
+    check(results[0].name == "cat", "highest-scoring detection keeps its class name");
+    check_close(results[0].confidence, 0.9f, "top detection confidence");
+    // Letterbox geometry: scale 0.5, pad_top 8. x_src = x/0.5, y_src = (y-8)/0.5.
+    check_close(results[0].x1, 20.0f, "box maps back to original x1");
+    check_close(results[0].y1, 4.0f, "box maps back to original y1");
+    check_close(results[0].x2, 60.0f, "box maps back to original x2");
+    check_close(results[0].y2, 44.0f, "box maps back to original y2");
+
+    check(results[1].name == "dog", "second detection keeps its class name");
+    check_close(results[1].confidence, 0.7f, "second detection confidence");
+    check_close(results[1].x1, 80.0f, "second box x1");
+    check_close(results[1].y2, 96.0f, "second box is clamped to the image height");
+
+    // The preprocessor must have produced a full CHW tensor in [0, 1].
+    check(observer->last_input().size() == static_cast<std::size_t>(64) * 64 * 3,
+          "engine received a complete CHW tensor");
+    bool in_range = true;
+    for (float value : observer->last_input()) {
+        if (value < 0.0f || value > 1.0f) {
+            in_range = false;
+            break;
+        }
+    }
+    check(in_range, "preprocessed tensor is normalised to [0, 1]");
+}
+
+void test_threshold_and_names() {
+    std::cout << "test_threshold_and_names\n";
+    lofop::Options options = stub_options();
+    options.score_threshold = 0.75f;
+    lofop::Detector detector(
+        std::unique_ptr<lofop::Engine>(new StubEngine(64)), options);
+    const auto results = detector.predict(make_test_image());
+    check(results.size() == 1, "raising the threshold drops the 0.7 detection");
+
+    lofop::Options unnamed;
+    lofop::Detector plain(
+        std::unique_ptr<lofop::Engine>(new StubEngine(64)), unnamed);
+    const auto fallback = plain.predict(make_test_image());
+    check(!fallback.empty() && fallback[0].name == "class_0",
+          "missing class names fall back to class_<index>");
+}
+
+void test_soft_nms_keeps_both() {
+    std::cout << "test_soft_nms_keeps_both\n";
+    lofop::Options options = stub_options();
+    options.soft_nms = true;
+    lofop::Detector detector(
+        std::unique_ptr<lofop::Engine>(new StubEngine(64)), options);
+    const auto results = detector.predict(make_test_image());
+    // Soft-NMS decays the duplicate's score rather than deleting it, so it
+    // survives where greedy NMS removed it.
+    check(results.size() >= 2, "soft-NMS retains decayed duplicates");
+}
+
+void test_error_paths() {
+    std::cout << "test_error_paths\n";
+    bool threw = false;
+    try {
+        lofop::Detector detector(std::unique_ptr<lofop::Engine>(), lofop::Options{});
+    } catch (const lofop::Error&) {
+        threw = true;
+    }
+    check(threw, "a null engine is rejected");
+
+    threw = false;
+    try {
+        lofop::Detector detector(
+            std::unique_ptr<lofop::Engine>(new StubEngine(64)), stub_options());
+        detector.predict(lofop::Image());
+    } catch (const lofop::Error&) {
+        threw = true;
+    }
+    check(threw, "an empty image is rejected");
+
+    if (!lofop::has_onnxruntime()) {
+        threw = false;
+        std::string message;
+        try {
+            lofop::Detector detector("missing.onnx");
+        } catch (const lofop::Error& exc) {
+            threw = true;
+            message = exc.what();
+        }
+        check(threw, "loading a model without an ONNX Runtime build fails");
+        check(message.find("LOFOP_WITH_ONNXRUNTIME") != std::string::npos,
+              "the error explains how to enable the backend");
+    }
+}
+
+void test_c_abi() {
+    std::cout << "test_c_abi\n";
+    check(std::string(lofop_version()) == lofop::kVersion, "C ABI reports the SDK version");
+
+    lofop_options options;
+    lofop_options_default(&options);
+    check_close(options.score_threshold, 0.25f, "C ABI defaults match the C++ defaults");
+    check(options.max_detections == 300, "C ABI default detection cap");
+
+    // Failure path: a model that cannot be loaded must return NULL and leave a
+    // message rather than propagating an exception across the boundary.
+    lofop_detector* handle = lofop_detector_create("does-not-exist.onnx", &options);
+    check(handle == nullptr, "creating a detector for a missing model returns NULL");
+    check(std::string(lofop_last_error()).size() > 0, "the failure leaves an error message");
+
+    check(lofop_detector_predict_path(nullptr, "x.ppm", nullptr) == LOFOP_ERROR,
+          "null handle is reported, not dereferenced");
+    check(lofop_detector_input_size(nullptr) == LOFOP_ERROR, "null handle input size is an error");
+    lofop_detector_free(nullptr);  // must be safe
+}
+
+}  // namespace
+
+int main() {
+    std::cout << "LOFOP C++ SDK tests (onnxruntime backend: "
+              << (lofop::has_onnxruntime() ? "on" : "off") << ")\n";
+    test_image_construction();
+    test_predict_pipeline();
+    test_threshold_and_names();
+    test_soft_nms_keeps_both();
+    test_error_paths();
+    test_c_abi();
+    std::cout << (g_failures == 0 ? "PASSED " : "FAILED ") << (g_checks - g_failures) << '/'
+              << g_checks << " checks\n";
+    return g_failures == 0 ? 0 : 1;
+}

--- a/docs/cpp-sdk.md
+++ b/docs/cpp-sdk.md
@@ -1,0 +1,200 @@
+# LOFOP C++ SDK
+
+Run a LOFOP detector from a C++ process, with no Python and no PyTorch in the
+deployed artifact.
+
+```cpp
+#include <lofop/lofop.hpp>
+
+lofop::Detector model("model.onnx");
+for (const auto& hit : model.predict("image.ppm")) {
+    std::cout << hit.name << ' ' << hit.confidence << '\n';
+}
+```
+
+The Python equivalent is the same three types with the same names:
+
+```python
+from lofop.runtime import Detector
+
+model = Detector("model.onnx")
+for hit in model.predict("image.jpg"):
+    print(hit.name, hit.confidence, hit.box)
+```
+
+Both consume the same `model.onnx` and return the same detections.
+
+## How the two runtimes stay identical
+
+They are not two implementations. They are two thin bindings over one:
+
+| Stage | Implementation | Used by |
+| --- | --- | --- |
+| Preprocess (letterbox) | `lofop/csrc/preprocess.cpp` | both |
+| Execute the graph | ONNX Runtime | both |
+| Dense decode | `lofop_decode_dense` in `lofop/csrc/box_ops.cpp` | both |
+| NMS / Soft-NMS | `lofop_nms`, `lofop_soft_nms` in `box_ops.cpp` | both |
+| Map boxes back | `lofop_unletterbox_boxes` in `preprocess.cpp` | both |
+
+Python reaches those kernels through `ctypes`; the C++ SDK compiles the same
+source files directly. Nothing numerical is written twice, so the runtimes
+cannot drift.
+
+The one exception is preprocessing, which additionally has a pure Python
+reference so LOFOP still runs where no compiler exists. That reference is the
+specification, and `tests/ops/test_preprocess.py` asserts the kernel matches it
+to float32 epsilon across upscales, downscales, extreme aspect ratios, and
+grayscale input. If they ever disagree, CI fails.
+
+## Building
+
+Requires CMake 3.16+ and any C++17 compiler.
+
+```bash
+cmake -S cpp -B build
+cmake --build build
+ctest --test-dir build --output-on-failure
+```
+
+That builds and tests the whole pipeline **without ONNX Runtime**. Execution
+sits behind the `lofop::Engine` interface, so only loading a `.onnx` by path
+needs the backend; everything LOFOP itself implements is exercised through a
+stub engine in the test suite.
+
+To run real models, point the build at an
+[ONNX Runtime release](https://github.com/microsoft/onnxruntime/releases):
+
+```bash
+cmake -S cpp -B build -DLOFOP_WITH_ONNXRUNTIME=ON -DONNXRUNTIME_ROOT=/path/to/onnxruntime
+cmake --build build
+./build/detect_image model.onnx image.ppm
+```
+
+### Build options
+
+| Option | Default | Effect |
+| --- | --- | --- |
+| `LOFOP_WITH_ONNXRUNTIME` | `OFF` | Enables loading `.onnx` files by path |
+| `LOFOP_WITH_STB_IMAGE` | `OFF` | Adds JPEG/PNG decoding via a vendored `stb_image.h` |
+| `LOFOP_BUILD_TESTS` | `ON` | Builds the SDK test suite |
+| `LOFOP_BUILD_EXAMPLES` | `ON` | Builds `detect_image` |
+| `BUILD_SHARED_LIBS` | `OFF` | Shared instead of static library |
+
+## Producing a model
+
+The SDK consumes the same artifact the Python deployment path does:
+
+```bash
+lofop export --config lofop/configs/lofop-detect/s.yaml \
+             --checkpoint runs/train/best.pt -o model.onnx
+```
+
+The exported graph includes box decoding and is verified numerically against
+the torch model at export time, so the handoff between languages is a tested
+contract rather than an assumption.
+
+Segmentation and pose variants are not exportable to ONNX yet, so the SDK
+covers detection models.
+
+## API
+
+### `lofop::Image`
+
+An 8-bit image in row-major HWC layout.
+
+```cpp
+// Pixels you already hold -- a decoded frame, a cv::Mat, a camera buffer.
+auto image = lofop::Image::from_pixels(mat.data, mat.cols, mat.rows, 3);
+
+// Or read a file. Binary PPM/PGM needs no dependencies; build with
+// LOFOP_WITH_STB_IMAGE for JPEG, PNG, and the rest.
+auto image = lofop::Image::load("frame.ppm");
+```
+
+Decoding deliberately stays out of LOFOP's scope: production callers almost
+always already have pixels, and forcing an image-codec dependency on them would
+be a cost with no benefit.
+
+### `lofop::Options`
+
+```cpp
+lofop::Options options;
+options.score_threshold = 0.5f;      // default 0.25
+options.nms_iou         = 0.6f;
+options.max_detections  = 300;
+options.image_size      = 0;         // 0 = read it from the graph
+options.pad_value       = 0.447f;    // letterbox fill
+options.soft_nms        = false;     // true = Soft-NMS score decay
+options.class_names     = {"cat", "dog"};
+```
+
+The defaults match `lofop.runtime.Detector`, so neither side restates them.
+
+### `lofop::Detection`
+
+`x1`, `y1`, `x2`, `y2` in the source image's own pixels, plus `confidence`,
+`label`, and `name`, with `width()`, `height()`, and `area()` helpers.
+
+### `lofop::Engine`
+
+Graph execution is an interface, which is what makes ONNX Runtime a choice
+rather than a dependency. Implement it to add a backend — TensorRT, OpenVINO,
+or a fixture in your own tests:
+
+```cpp
+class MyEngine : public lofop::Engine {
+    lofop::DenseOutput run(const float* nchw, std::size_t length) override;
+    int input_size() const override;
+    std::string backend() const override;
+};
+
+lofop::Detector detector(std::make_unique<MyEngine>(), options);
+```
+
+## The C ABI
+
+`include/lofop/lofop_c.h` exposes the same pipeline through a flat C ABI, for
+Go (cgo), Rust (FFI), C# (P/Invoke), and Java (JNI/FFM). No exception ever
+crosses the boundary: calls return a status and leave a message in
+`lofop_last_error()`.
+
+```c
+#include <lofop/lofop_c.h>
+
+lofop_options options;
+lofop_options_default(&options);
+
+lofop_detector* det = lofop_detector_create("model.onnx", &options);
+if (det == NULL) { fprintf(stderr, "%s\n", lofop_last_error()); return 1; }
+
+const lofop_detection* hits = NULL;
+int32_t n = lofop_detector_predict_path(det, "image.ppm", &hits);
+for (int32_t i = 0; i < n; ++i) {
+    printf("%d %.3f [%.1f %.1f %.1f %.1f]\n", hits[i].label, hits[i].confidence,
+           hits[i].x1, hits[i].y1, hits[i].x2, hits[i].y2);
+}
+lofop_detector_free(det);
+```
+
+A C ABI rather than pybind11 is a deliberate choice, and the same one
+TensorFlow made for `libtensorflow`: it is stable across compilers and Python
+versions, needs no build step at install time, and is the only boundary every
+other language can bind to.
+
+## What this does not change
+
+Adding the C++ SDK changed nothing about training. `lofop.Detector` — the
+PyTorch build/train/export API — is untouched, and `lofop.runtime.Detector` is
+a separate class in a separate module reached by a separate import:
+
+```python
+from lofop import Detector            # PyTorch: build, train, export
+from lofop.runtime import Detector    # ONNX: deploy, no torch
+```
+
+The two never shadow each other, and `lofop.runtime` imports no torch at all —
+a property the test suite enforces in a clean interpreter, since that is what
+lets a deployment image omit PyTorch entirely.
+
+The `cpp/` directory is likewise self-contained: it can be built, shipped, or
+deleted without affecting the Python package.

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -38,8 +38,8 @@ It uses **PyPI Trusted Publishing (OIDC)** — no API token is stored in the rep
 ```bash
 # 1. Bump the version in lofop/version.py AND pyproject.toml, commit, merge to main.
 # 2. Tag and push:
-git tag v1.2.0      # match the version in pyproject.toml
-git push origin v1.2.0
+git tag v1.2.1      # match the version in pyproject.toml
+git push origin v1.2.1
 ```
 
 The workflow builds, checks, and publishes. `pip install lofop` serves it within a minute.
@@ -65,7 +65,7 @@ makepkg -si                                 # optional: build+install locally to
 # Push to the AUR (requires an AUR account + registered SSH key):
 git clone ssh://aur@aur.archlinux.org/lofop.git aur-lofop
 cp PKGBUILD .SRCINFO aur-lofop/
-cd aur-lofop && git commit -am "lofop 1.2.0" && git push
+cd aur-lofop && git commit -am "lofop 1.2.1" && git push
 ```
 
 After that, `yay -S lofop` (or any AUR helper) installs it. Optional features map to AUR

--- a/lofop/csrc/preprocess.cpp
+++ b/lofop/csrc/preprocess.cpp
@@ -1,0 +1,168 @@
+// Native image preprocessing for LOFOP inference.
+//
+// Detection accuracy depends on the training and serving pipelines preparing
+// pixels identically. Defining that transform twice -- once in Python, once in
+// C++ -- invites silent drift: a half-pixel disagreement costs accuracy with
+// no error to trace. So the transform is defined exactly once, here, and both
+// language bindings call this code.
+//
+// `lofop_letterbox` performs an aspect-preserving resize with symmetric
+// padding (the standard detector preprocessing) and writes the CHW float
+// tensor a model consumes; `lofop_unletterbox_boxes` maps predicted boxes
+// back to original image coordinates. The two are exact inverses of each
+// other's geometry.
+//
+// Exposed through a plain C ABI (loaded via ctypes, linked directly by the
+// C++ SDK) so the library builds with any C++17 compiler and needs no Python
+// headers, no pybind11, and no framework runtime.
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+namespace {
+
+// Bilinear sample of one channel at a source position, clamped at the edges.
+// LOFOP deliberately defines its own sampler rather than matching a specific
+// imaging library: the requirement is that Python and C++ agree bit-for-bit,
+// which a small, fully specified kernel guarantees and a third-party
+// resampler (whose antialiasing differs between versions) does not.
+// Sampling positions are computed in double throughout. On a heavy downscale
+// the destination-to-source product grows large enough that float32 rounding
+// shifts the sample by microns of a pixel -- harmless on its own, but it makes
+// the C++ and Python results diverge by more than the 8-bit input can justify.
+// Double positions keep the two implementations agreeing to float32 epsilon at
+// no measurable cost: this loop is memory-bound, not arithmetic-bound.
+inline float sample_bilinear(const uint8_t* src, int32_t width, int32_t height,
+                             int32_t channels, int32_t channel, double x, double y) {
+    if (x < 0.0) {
+        x = 0.0;
+    }
+    if (y < 0.0) {
+        y = 0.0;
+    }
+    const double max_x = static_cast<double>(width - 1);
+    const double max_y = static_cast<double>(height - 1);
+    if (x > max_x) {
+        x = max_x;
+    }
+    if (y > max_y) {
+        y = max_y;
+    }
+    const int32_t x0 = static_cast<int32_t>(x);
+    const int32_t y0 = static_cast<int32_t>(y);
+    const int32_t x1 = (x0 + 1 < width) ? x0 + 1 : x0;
+    const int32_t y1 = (y0 + 1 < height) ? y0 + 1 : y0;
+    const double fx = x - static_cast<double>(x0);
+    const double fy = y - static_cast<double>(y0);
+
+    const int64_t stride = static_cast<int64_t>(width) * channels;
+    const double p00 = src[static_cast<int64_t>(y0) * stride + static_cast<int64_t>(x0) * channels + channel];
+    const double p01 = src[static_cast<int64_t>(y0) * stride + static_cast<int64_t>(x1) * channels + channel];
+    const double p10 = src[static_cast<int64_t>(y1) * stride + static_cast<int64_t>(x0) * channels + channel];
+    const double p11 = src[static_cast<int64_t>(y1) * stride + static_cast<int64_t>(x1) * channels + channel];
+
+    const double top = p00 + (p01 - p00) * fx;
+    const double bottom = p10 + (p11 - p10) * fx;
+    return static_cast<float>(top + (bottom - top) * fy);
+}
+
+}  // namespace
+
+extern "C" {
+
+// Aspect-preserving resize of an HWC uint8 image into a CHW float32 tensor.
+//
+//   src       (sh, sw, channels) uint8, channels 1 or 3; 1 is broadcast to 3
+//   size      side length of the square destination
+//   pad_value fill for the padded margin, in [0, 1]
+//   dst       (3, size, size) float32 in [0, 1], caller-allocated
+//   meta      [scale, pad_left, pad_top], caller-allocated (3 floats)
+//
+// Returns 0 on success, -1 on invalid arguments.
+int32_t lofop_letterbox(const uint8_t* src, int32_t sw, int32_t sh, int32_t channels,
+                        int32_t size, float pad_value, float* dst, float* meta) {
+    if (src == nullptr || dst == nullptr || meta == nullptr) {
+        return -1;
+    }
+    if (sw <= 0 || sh <= 0 || size <= 0 || (channels != 1 && channels != 3)) {
+        return -1;
+    }
+
+    const float scale = std::min(static_cast<float>(size) / static_cast<float>(sw),
+                                 static_cast<float>(size) / static_cast<float>(sh));
+    // Round to nearest, then clamp: a scale of exactly 1 must not round the
+    // extent past the destination on either axis.
+    int32_t new_w = static_cast<int32_t>(std::lround(static_cast<double>(sw) * scale));
+    int32_t new_h = static_cast<int32_t>(std::lround(static_cast<double>(sh) * scale));
+    new_w = std::max(1, std::min(new_w, size));
+    new_h = std::max(1, std::min(new_h, size));
+    const int32_t pad_left = (size - new_w) / 2;
+    const int32_t pad_top = (size - new_h) / 2;
+
+    const int64_t plane = static_cast<int64_t>(size) * size;
+    for (int64_t i = 0; i < plane * 3; ++i) {
+        dst[i] = pad_value;
+    }
+
+    // Map destination pixel centres back through the scale, the convention
+    // that keeps the transform symmetric and its inverse exact.
+    const double inv_scale_x = static_cast<double>(sw) / static_cast<double>(new_w);
+    const double inv_scale_y = static_cast<double>(sh) / static_cast<double>(new_h);
+    for (int32_t y = 0; y < new_h; ++y) {
+        const double src_y = (static_cast<double>(y) + 0.5) * inv_scale_y - 0.5;
+        for (int32_t x = 0; x < new_w; ++x) {
+            const double src_x = (static_cast<double>(x) + 0.5) * inv_scale_x - 0.5;
+            const int64_t offset = static_cast<int64_t>(y + pad_top) * size + (x + pad_left);
+            for (int32_t c = 0; c < 3; ++c) {
+                const int32_t source_channel = (channels == 1) ? 0 : c;
+                const float value =
+                    sample_bilinear(src, sw, sh, channels, source_channel, src_x, src_y);
+                dst[static_cast<int64_t>(c) * plane + offset] = value / 255.0f;
+            }
+        }
+    }
+
+    meta[0] = scale;
+    meta[1] = static_cast<float>(pad_left);
+    meta[2] = static_cast<float>(pad_top);
+    return 0;
+}
+
+// Map boxes from letterboxed coordinates back to original image pixels,
+// undoing `lofop_letterbox`'s padding and scale and clamping to the image.
+//
+//   boxes  (n, 4) float32 xyxy in letterboxed pixels; updated in place when
+//          `out` aliases it, otherwise written to `out`
+//   meta   [scale, pad_left, pad_top] as produced by lofop_letterbox
+//
+// Returns 0 on success, -1 on invalid arguments.
+int32_t lofop_unletterbox_boxes(const float* boxes, int32_t n, const float* meta,
+                                int32_t width, int32_t height, float* out) {
+    if (boxes == nullptr || meta == nullptr || out == nullptr || n < 0) {
+        return -1;
+    }
+    const float scale = meta[0];
+    if (!(scale > 0.0f)) {
+        return -1;
+    }
+    const float pad_left = meta[1];
+    const float pad_top = meta[2];
+    const float max_x = static_cast<float>(width);
+    const float max_y = static_cast<float>(height);
+    for (int32_t i = 0; i < n; ++i) {
+        const float* box = boxes + static_cast<int64_t>(i) * 4;
+        float* dst = out + static_cast<int64_t>(i) * 4;
+        const float x1 = (box[0] - pad_left) / scale;
+        const float y1 = (box[1] - pad_top) / scale;
+        const float x2 = (box[2] - pad_left) / scale;
+        const float y2 = (box[3] - pad_top) / scale;
+        dst[0] = std::min(std::max(x1, 0.0f), max_x);
+        dst[1] = std::min(std::max(y1, 0.0f), max_y);
+        dst[2] = std::min(std::max(x2, 0.0f), max_x);
+        dst[3] = std::min(std::max(y2, 0.0f), max_y);
+    }
+    return 0;
+}
+
+}  // extern "C"

--- a/lofop/models/detector.py
+++ b/lofop/models/detector.py
@@ -18,7 +18,7 @@ from lofop.core.exceptions import ModelError
 from lofop.models.assigner import DynamicTopKAssigner
 from lofop.models.head import ApexHead
 from lofop.models.losses import giou_loss, sigmoid_focal_loss
-from lofop.ops import nms
+from lofop.ops import nms, soft_nms
 from lofop.ops.boxes import CLASS_OFFSET
 from lofop.registries import MODELS
 
@@ -49,7 +49,16 @@ class LofopDetect(nn.Module):
         score_threshold: Minimum score for a detection at inference.
         nms_iou: IoU threshold for class-aware NMS.
         max_detections: Detections kept per image after NMS.
+        nms_mode: Duplicate-removal strategy at inference. ``"greedy"``
+            (default) is classic class-aware NMS; ``"soft"`` decays
+            overlapping scores instead of dropping (better in crowds);
+            ``"free"`` is NMS-free -- keep only locations that are the local
+            score peak of their 3x3 neighborhood on their pyramid level, so
+            inference is pure tensor math with no suppression loop at all.
+        soft_nms_sigma: Gaussian decay width for ``nms_mode="soft"``.
     """
+
+    _NMS_MODES = ("greedy", "soft", "free")
 
     def __init__(
         self,
@@ -60,11 +69,17 @@ class LofopDetect(nn.Module):
         score_threshold: float = 0.05,
         nms_iou: float = 0.6,
         max_detections: int = 300,
+        nms_mode: str = "greedy",
+        soft_nms_sigma: float = 0.5,
     ) -> None:
         super().__init__()
         if not isinstance(head, ApexHead):
             got = type(head).__name__
             raise ModelError("LofopDetect requires an ApexHead", context={"got": got})
+        if nms_mode not in self._NMS_MODES:
+            raise ModelError(
+                "Unknown nms_mode", context={"got": nms_mode, "known": list(self._NMS_MODES)}
+            )
         self.backbone = backbone
         self.neck = neck
         self.head = head
@@ -73,6 +88,8 @@ class LofopDetect(nn.Module):
         self.score_threshold = score_threshold
         self.nms_iou = nms_iou
         self.max_detections = max_detections
+        self.nms_mode = nms_mode
+        self.soft_nms_sigma = soft_nms_sigma
         self._channels_last = False
 
     def _features(self, images: Tensor) -> list[Tensor]:
@@ -228,31 +245,68 @@ class LofopDetect(nn.Module):
         points, _ = self.head.level_points(cls_out)
         cls, box, quality = self._flatten(cls_out, box_out, quality_out)
         scores_all = (cls.sigmoid() * quality.sigmoid().unsqueeze(-1)).sqrt()
+        peaks = self._peak_mask(cls_out, quality_out) if self.nms_mode == "free" else None
 
         results = []
         for image_index in range(images.shape[0]):
             scores, labels = scores_all[image_index].max(dim=1)
             keep_mask = scores > self.score_threshold
+            if peaks is not None:
+                keep_mask &= peaks[image_index]
             if not keep_mask.any():
                 results.append(self._empty_result(images))
                 continue
             location_index = keep_mask.nonzero(as_tuple=False).squeeze(1)
             boxes = self.head.decode_boxes(points[keep_mask], box[image_index][keep_mask])
             scores, labels = scores[keep_mask], labels[keep_mask]
-            # Class-aware NMS via the coordinate-offset shift done in tensor
-            # math; contiguous float32 tensors hit the zero-copy native path
-            # in lofop.ops instead of a per-element Python list conversion.
-            shifted = boxes + (labels.to(boxes.dtype) * CLASS_OFFSET).unsqueeze(1)
-            keep = nms(
-                shifted.contiguous(), scores.contiguous(),
-                iou_threshold=self.nms_iou, max_keep=self.max_detections,
-            )
-            index = torch.as_tensor(keep, dtype=torch.long, device=images.device)
+            if self.nms_mode == "free":
+                # Peak selection already removed duplicates; just rank.
+                index = scores.argsort(descending=True)
+                if self.max_detections > 0:
+                    index = index[: self.max_detections]
+            elif self.nms_mode == "soft":
+                shifted = boxes + (labels.to(boxes.dtype) * CLASS_OFFSET).unsqueeze(1)
+                keep, kept_scores = soft_nms(
+                    shifted.contiguous(), scores.contiguous(),
+                    sigma=self.soft_nms_sigma, score_threshold=self.score_threshold,
+                    max_keep=self.max_detections,
+                )
+                index = torch.as_tensor(keep, dtype=torch.long, device=images.device)
+                scores = torch.as_tensor(
+                    kept_scores, dtype=boxes.dtype, device=images.device
+                )
+                results.append({
+                    "boxes": boxes[index], "scores": scores, "labels": labels[index],
+                    "locations": location_index[index],
+                })
+                continue
+            else:
+                # Class-aware NMS via the coordinate-offset shift done in
+                # tensor math; contiguous float32 tensors hit the zero-copy
+                # native path in lofop.ops instead of a per-element Python
+                # list conversion.
+                shifted = boxes + (labels.to(boxes.dtype) * CLASS_OFFSET).unsqueeze(1)
+                keep = nms(
+                    shifted.contiguous(), scores.contiguous(),
+                    iou_threshold=self.nms_iou, max_keep=self.max_detections,
+                )
+                index = torch.as_tensor(keep, dtype=torch.long, device=images.device)
             results.append({
                 "boxes": boxes[index], "scores": scores[index], "labels": labels[index],
                 "locations": location_index[index],
             })
         return results
+
+    def _peak_mask(self, cls_out: list[Tensor], quality_out: list[Tensor]) -> Tensor:
+        """(B, N) mask of locations that are their 3x3 neighborhood's score
+        peak on their own pyramid level -- the NMS-free selection rule."""
+        masks = []
+        for cls_map, quality_map in zip(cls_out, quality_out):
+            fused = (cls_map.sigmoid().amax(dim=1, keepdim=True)
+                     * quality_map.sigmoid()).sqrt()
+            pooled = F.max_pool2d(fused, kernel_size=3, stride=1, padding=1)
+            masks.append((fused >= pooled).squeeze(1).flatten(1))
+        return torch.cat(masks, dim=1)
 
     @staticmethod
     def _empty_result(images: Tensor) -> dict[str, Any]:

--- a/lofop/ops/__init__.py
+++ b/lofop/ops/__init__.py
@@ -9,8 +9,10 @@ parallel ops on NVIDIA GPUs. :func:`backend` reports the active tier.
 
 from lofop.ops.boxes import batched_nms, decode_dense, iou_matrix, nms, soft_nms
 from lofop.ops.native import backend, build_native, find_library, load_native, load_native_cuda
+from lofop.ops.preprocess import LetterboxMeta, letterbox, unletterbox_boxes
 
 __all__ = [
     "iou_matrix", "nms", "batched_nms", "soft_nms", "decode_dense",
+    "letterbox", "unletterbox_boxes", "LetterboxMeta",
     "backend", "build_native", "find_library", "load_native", "load_native_cuda",
 ]

--- a/lofop/ops/boxes.py
+++ b/lofop/ops/boxes.py
@@ -338,12 +338,22 @@ def decode_dense(
     count = n * num_classes
     if lib is not None and hasattr(lib, "lofop_decode_dense"):
         c_scores, keepalive = _c_float_view(class_scores, count)
-        if c_scores is None:
+        copied = c_scores is None or isinstance(c_scores, ctypes.Array)
+        if copied and native is not True:
+            # Measured: flattening N*C Python floats into a C buffer costs
+            # more than the pure Python argmax loop, so the native kernel is
+            # auto-selected only for zero-copy inputs (contiguous float32
+            # numpy arrays / CPU tensors -- the deployment hot path, 35-48x).
+            c_scores = None
+        if c_scores is None and native is not True:
+            lib = None
+        elif c_scores is None:
             flat = [float(v) for row in class_scores for v in row]
             if len(flat) != count:
                 raise LofopError("class_scores rows must have equal length")
             c_scores = (ctypes.c_float * count)(*flat)
             keepalive = c_scores
+    if lib is not None and hasattr(lib, "lofop_decode_dense"):
         idx = (ctypes.c_int32 * n)()
         labels = (ctypes.c_int32 * n)()
         out_scores = (ctypes.c_float * n)()

--- a/lofop/ops/native.py
+++ b/lofop/ops/native.py
@@ -36,8 +36,12 @@ from lofop.core.logging import get_logger
 
 _LIB_STEM = "_lofop_ops"
 _CUDA_LIB_STEM = "_lofop_ops_cuda"
-_SOURCE = Path(__file__).resolve().parent.parent / "csrc" / "box_ops.cpp"
-_CUDA_SOURCE = Path(__file__).resolve().parent.parent / "csrc" / "box_ops.cu"
+_CSRC = Path(__file__).resolve().parent.parent / "csrc"
+_SOURCE = _CSRC / "box_ops.cpp"
+# Every translation unit compiled into the native library. Kept as a list so
+# new kernels are added by appending here; the C++ SDK links the same files.
+_SOURCES = [_SOURCE, _CSRC / "preprocess.cpp"]
+_CUDA_SOURCE = _CSRC / "box_ops.cu"
 _IS_WINDOWS = sys.platform.startswith("win")
 
 logger = get_logger(__name__)
@@ -75,12 +79,20 @@ def _compiler_candidates(explicit: str | None) -> list[str]:
     return [name for name in preference if shutil.which(name)] or preference
 
 
-def _build_command(compiler: str, source: Path, target: Path) -> tuple[list[str], Path | None]:
+def _build_command(
+    compiler: str, source: Path | list[Path], target: Path
+) -> tuple[list[str], Path | None]:
     """Build the compile command for a toolchain.
+
+    Args:
+        compiler: Compiler binary.
+        source: One source file, or a list of them compiled into one library.
+        target: Output library path.
 
     Returns the argv plus an optional working directory (MSVC scatters
     intermediate .obj/.lib files into cwd, so it runs in a temp dir).
     """
+    sources = [source] if isinstance(source, Path) else list(source)
     # Separator-agnostic basename so a Windows "C:\\VS\\cl.exe" path is
     # recognized even when parsed on a POSIX host (and vice versa).
     base = compiler.replace("\\", "/").rsplit("/", 1)[-1].lower()
@@ -89,7 +101,7 @@ def _build_command(compiler: str, source: Path, target: Path) -> tuple[list[str]
         workdir = Path(tempfile.mkdtemp(prefix="lofop_build_"))
         cmd = [
             compiler, "/nologo", "/O2", "/std:c++17", "/EHsc", "/LD",
-            str(source), f"/Fe:{target}", f"/Fo:{workdir}\\",
+            *[str(path) for path in sources], f"/Fe:{target}", f"/Fo:{workdir}\\",
         ]
         return cmd, workdir
     # GNU/Clang-style front end (g++, clang++, c++, MinGW g++).
@@ -100,7 +112,8 @@ def _build_command(compiler: str, source: Path, target: Path) -> tuple[list[str]
         cmd += ["-static-libgcc", "-static-libstdc++"]
     else:
         cmd.append("-fPIC")
-    cmd += [str(source), "-o", str(target)]
+    cmd += [str(path) for path in sources]
+    cmd += ["-o", str(target)]
     return cmd, None
 
 
@@ -134,7 +147,7 @@ def build_native(*, force: bool = False, compiler: str | None = None,
             continue
         for target in _candidate_paths():
             target.parent.mkdir(parents=True, exist_ok=True)
-            cmd, workdir = _build_command(binary, _SOURCE, target)
+            cmd, workdir = _build_command(binary, _SOURCES, target)
             try:
                 subprocess.run(cmd, check=True, capture_output=True, text=True, cwd=workdir)
             except FileNotFoundError:
@@ -244,6 +257,19 @@ def load_native() -> ctypes.CDLL | None:
             ctypes.POINTER(ctypes.c_float),
         ]
         lib.lofop_decode_dense.restype = ctypes.c_int32
+    if hasattr(lib, "lofop_letterbox"):
+        lib.lofop_letterbox.argtypes = [
+            ctypes.POINTER(ctypes.c_uint8), ctypes.c_int32, ctypes.c_int32, ctypes.c_int32,
+            ctypes.c_int32, ctypes.c_float,
+            ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+        ]
+        lib.lofop_letterbox.restype = ctypes.c_int32
+    if hasattr(lib, "lofop_unletterbox_boxes"):
+        lib.lofop_unletterbox_boxes.argtypes = [
+            ctypes.POINTER(ctypes.c_float), ctypes.c_int32, ctypes.POINTER(ctypes.c_float),
+            ctypes.c_int32, ctypes.c_int32, ctypes.POINTER(ctypes.c_float),
+        ]
+        lib.lofop_unletterbox_boxes.restype = ctypes.c_int32
     _loaded = lib
     logger.debug("Loaded native ops library from %s", path)
     return lib

--- a/lofop/ops/preprocess.py
+++ b/lofop/ops/preprocess.py
@@ -1,0 +1,233 @@
+"""Image preprocessing shared by every LOFOP inference path.
+
+Aspect-preserving resize with symmetric padding ("letterboxing") is the
+transform a detector's accuracy is calibrated against, so training and serving
+must apply it identically. This module is the Python half of a single shared
+definition: :func:`letterbox` dispatches to the C++ kernel in
+``lofop/csrc/preprocess.cpp`` when the native library is built, and otherwise
+runs a pure Python reference that computes the same result. The C++ SDK links
+that same source file, so all three paths agree by construction rather than by
+convention -- and ``tests/ops/test_preprocess.py`` proves it.
+
+Torch-free by design: this runs anywhere the LOFOP core runs, which is what
+lets the deployment path drop PyTorch entirely.
+"""
+
+from __future__ import annotations
+
+import ctypes
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from lofop.core.exceptions import DataError
+from lofop.ops.native import load_native
+
+__all__ = ["LetterboxMeta", "letterbox", "unletterbox_boxes"]
+
+
+@dataclass(frozen=True)
+class LetterboxMeta:
+    """Geometry of one letterbox transform, enough to invert it.
+
+    Attributes:
+        scale: Factor the original image was multiplied by.
+        pad_left: Pixels of padding added on the left.
+        pad_top: Pixels of padding added on the top.
+        width: Original image width.
+        height: Original image height.
+    """
+
+    scale: float
+    pad_left: float
+    pad_top: float
+    width: int
+    height: int
+
+
+def _sample_bilinear(
+    pixels: Sequence[int], width: int, height: int, channels: int,
+    channel: int, x: float, y: float,
+) -> float:
+    """Bilinear sample of one channel, clamped at the edges.
+
+    Mirrors ``sample_bilinear`` in ``csrc/preprocess.cpp`` exactly; the two are
+    the specification of LOFOP's resampling and must not diverge.
+    """
+    x = min(max(x, 0.0), float(width - 1))
+    y = min(max(y, 0.0), float(height - 1))
+    x0 = int(x)
+    y0 = int(y)
+    x1 = x0 + 1 if x0 + 1 < width else x0
+    y1 = y0 + 1 if y0 + 1 < height else y0
+    fx = x - x0
+    fy = y - y0
+    stride = width * channels
+    p00 = pixels[y0 * stride + x0 * channels + channel]
+    p01 = pixels[y0 * stride + x1 * channels + channel]
+    p10 = pixels[y1 * stride + x0 * channels + channel]
+    p11 = pixels[y1 * stride + x1 * channels + channel]
+    top = p00 + (p01 - p00) * fx
+    bottom = p10 + (p11 - p10) * fx
+    return top + (bottom - top) * fy
+
+
+def _letterbox_geometry(width: int, height: int, size: int) -> tuple[float, int, int, int, int]:
+    """Scale, destination extent, and padding for one letterbox.
+
+    Shared by both implementations so the geometry cannot drift even if the
+    resampling loops do.
+    """
+    scale = min(size / width, size / height)
+    # round-half-away-from-zero, matching std::lround in the C++ kernel;
+    # Python's round() is banker's rounding and would disagree on .5 cases.
+    new_w = int(width * scale + 0.5)
+    new_h = int(height * scale + 0.5)
+    new_w = max(1, min(new_w, size))
+    new_h = max(1, min(new_h, size))
+    return scale, new_w, new_h, (size - new_w) // 2, (size - new_h) // 2
+
+
+def _letterbox_python(
+    pixels: Sequence[int], width: int, height: int, channels: int,
+    size: int, pad_value: float,
+) -> tuple[list[float], LetterboxMeta]:
+    """Pure Python reference implementation. Always available."""
+    scale, new_w, new_h, pad_left, pad_top = _letterbox_geometry(width, height, size)
+    plane = size * size
+    out = [pad_value] * (plane * 3)
+    inv_scale_x = width / new_w
+    inv_scale_y = height / new_h
+    for y in range(new_h):
+        src_y = (y + 0.5) * inv_scale_y - 0.5
+        row = (y + pad_top) * size
+        for x in range(new_w):
+            src_x = (x + 0.5) * inv_scale_x - 0.5
+            offset = row + x + pad_left
+            for c in range(3):
+                source_channel = 0 if channels == 1 else c
+                value = _sample_bilinear(
+                    pixels, width, height, channels, source_channel, src_x, src_y
+                )
+                out[c * plane + offset] = value / 255.0
+    meta = LetterboxMeta(float(scale), float(pad_left), float(pad_top), width, height)
+    return out, meta
+
+
+def letterbox(
+    pixels: Sequence[int] | bytes | bytearray,
+    width: int,
+    height: int,
+    *,
+    channels: int = 3,
+    size: int = 640,
+    pad_value: float = 0.447,
+) -> tuple[list[float], LetterboxMeta]:
+    """Resize an image into a square model input, preserving aspect ratio.
+
+    Args:
+        pixels: Row-major HWC pixel data, 8-bit per channel (a ``bytes``
+            buffer, ``bytearray``, or any integer sequence).
+        width: Source image width in pixels.
+        height: Source image height in pixels.
+        channels: Channels in ``pixels`` -- 1 (broadcast to RGB) or 3.
+        size: Side length of the square destination.
+        pad_value: Fill value for the padded margin, in ``[0, 1]``. The
+            default is the mid-grey conventionally used by detectors, which
+            keeps padding from reading as a dark object edge.
+
+    Returns:
+        ``(tensor, meta)`` where ``tensor`` is a flat CHW float list of
+        length ``3 * size * size`` with values in ``[0, 1]``, and ``meta``
+        is the :class:`LetterboxMeta` needed to map boxes back.
+
+    Raises:
+        DataError: On invalid dimensions, channel count, or a pixel buffer
+            shorter than ``width * height * channels``.
+    """
+    if width <= 0 or height <= 0 or size <= 0:
+        raise DataError(
+            "letterbox needs positive dimensions",
+            context={"width": width, "height": height, "size": size},
+        )
+    if channels not in (1, 3):
+        raise DataError("letterbox supports 1 or 3 channels", context={"channels": channels})
+    expected = width * height * channels
+    if len(pixels) < expected:
+        raise DataError(
+            "pixel buffer is smaller than the declared image",
+            context={"expected": expected, "got": len(pixels)},
+        )
+
+    lib = load_native()
+    if lib is not None and hasattr(lib, "lofop_letterbox"):
+        buffer = pixels if isinstance(pixels, (bytes, bytearray)) else bytes(bytearray(pixels))
+        src = (ctypes.c_uint8 * expected).from_buffer_copy(buffer[:expected])
+        dst = (ctypes.c_float * (3 * size * size))()
+        meta_out = (ctypes.c_float * 3)()
+        status = lib.lofop_letterbox(
+            src, ctypes.c_int32(width), ctypes.c_int32(height), ctypes.c_int32(channels),
+            ctypes.c_int32(size), ctypes.c_float(pad_value), dst, meta_out,
+        )
+        if status == 0:
+            meta = LetterboxMeta(
+                float(meta_out[0]), float(meta_out[1]), float(meta_out[2]), width, height
+            )
+            return list(dst), meta
+        # A negative status means the kernel rejected the arguments; fall
+        # through to the reference so behaviour never depends on the tier.
+
+    return _letterbox_python(pixels, width, height, channels, size, pad_value)
+
+
+def unletterbox_boxes(
+    boxes: Sequence[Sequence[float]], meta: LetterboxMeta
+) -> list[list[float]]:
+    """Map boxes from letterboxed coordinates back to original image pixels.
+
+    The exact inverse of :func:`letterbox`'s geometry: padding is removed,
+    the scale undone, and boxes are clamped to the image bounds.
+
+    Args:
+        boxes: ``(N, 4)`` xyxy boxes in letterboxed pixel coordinates.
+        meta: Geometry returned by :func:`letterbox`.
+
+    Returns:
+        ``(N, 4)`` xyxy boxes in the original image's pixel coordinates.
+    """
+    if not boxes:
+        return []
+    if not meta.scale > 0:
+        raise DataError("letterbox meta has a non-positive scale",
+                        context={"scale": meta.scale})
+
+    lib = load_native()
+    if lib is not None and hasattr(lib, "lofop_unletterbox_boxes"):
+        count = len(boxes)
+        flat = (ctypes.c_float * (count * 4))()
+        for i, box in enumerate(boxes):
+            flat[i * 4] = float(box[0])
+            flat[i * 4 + 1] = float(box[1])
+            flat[i * 4 + 2] = float(box[2])
+            flat[i * 4 + 3] = float(box[3])
+        meta_in = (ctypes.c_float * 3)(meta.scale, meta.pad_left, meta.pad_top)
+        out = (ctypes.c_float * (count * 4))()
+        status = lib.lofop_unletterbox_boxes(
+            flat, ctypes.c_int32(count), meta_in,
+            ctypes.c_int32(meta.width), ctypes.c_int32(meta.height), out,
+        )
+        if status == 0:
+            return [list(out[i * 4:i * 4 + 4]) for i in range(count)]
+
+    result = []
+    for box in boxes:
+        x1 = (float(box[0]) - meta.pad_left) / meta.scale
+        y1 = (float(box[1]) - meta.pad_top) / meta.scale
+        x2 = (float(box[2]) - meta.pad_left) / meta.scale
+        y2 = (float(box[3]) - meta.pad_top) / meta.scale
+        result.append([
+            min(max(x1, 0.0), float(meta.width)),
+            min(max(y1, 0.0), float(meta.height)),
+            min(max(x2, 0.0), float(meta.width)),
+            min(max(y2, 0.0), float(meta.height)),
+        ])
+    return result

--- a/lofop/runtime/__init__.py
+++ b/lofop/runtime/__init__.py
@@ -1,0 +1,25 @@
+"""LOFOP inference runtime: torch-free ONNX deployment.
+
+The serving counterpart to the training stack. Where :class:`lofop.Detector`
+builds and trains PyTorch models, this package runs an exported ``model.onnx``
+with no deep-learning framework attached -- ONNX Runtime executes the graph and
+LOFOP's own native kernels do the preprocessing and post-processing.
+
+It mirrors the C++ SDK in ``cpp/`` type for type (``Detector``, ``Detection``,
+``Image``) and shares its kernels, so the same model file produces the same
+detections from either language::
+
+    from lofop.runtime import Detector
+
+    model = Detector("model.onnx")
+    for hit in model.predict("image.jpg"):
+        print(hit.name, hit.confidence, hit.box)
+
+Requires ``onnxruntime`` and ``numpy``; both stay optional for the rest of
+LOFOP, and importing this package is what pulls them in.
+"""
+
+from lofop.runtime.detector import Detection, Detector
+from lofop.runtime.image import Image
+
+__all__ = ["Detector", "Detection", "Image"]

--- a/lofop/runtime/detector.py
+++ b/lofop/runtime/detector.py
@@ -1,0 +1,259 @@
+"""Torch-free ONNX inference for LOFOP detectors.
+
+This is the Python half of LOFOP's deployment runtime. Its C++ twin
+(``cpp/include/lofop/lofop.hpp``) exposes the same three types with the same
+names and the same semantics, and both drive the *same* native kernels:
+letterboxing from ``csrc/preprocess.cpp``, dense decoding and class-aware NMS
+from ``csrc/box_ops.cpp``. Given one ``model.onnx`` the two runtimes return
+identical detections, which is what makes "train in Python, serve in C++" a
+guarantee rather than an aspiration.
+
+It is entirely separate from :class:`lofop.Detector`, the PyTorch research and
+training API. Nothing here imports torch, and nothing here changes that class::
+
+    from lofop import Detector                 # PyTorch: build, train, export
+    from lofop.runtime import Detector         # ONNX: deploy, no torch
+
+Usage::
+
+    from lofop.runtime import Detector
+
+    model = Detector("model.onnx", class_names=["cat", "dog"])
+    for hit in model.predict("image.jpg"):
+        print(hit.name, hit.confidence, hit.box)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Union
+
+from lofop.core.exceptions import LofopError
+from lofop.core.logging import get_logger
+from lofop.deploy.postprocess import postprocess_dense
+from lofop.ops import backend as ops_backend
+from lofop.ops.preprocess import letterbox, unletterbox_boxes
+from lofop.runtime.image import Image
+
+logger = get_logger(__name__)
+
+__all__ = ["Detection", "Detector"]
+
+ImageSource = Union[str, Path, Image]
+
+_DEFAULT_SIZE = 640
+
+
+@dataclass(frozen=True)
+class Detection:
+    """One detected object, in original image coordinates.
+
+    Attributes:
+        box: ``(x1, y1, x2, y2)`` in the source image's own pixels.
+        score: Confidence in ``[0, 1]``.
+        label: Class index.
+        name: Class name, or ``"class_<index>"`` when no names were given.
+    """
+
+    box: tuple[float, float, float, float]
+    score: float
+    label: int
+    name: str
+
+    @property
+    def confidence(self) -> float:
+        """Alias for :attr:`score`, matching the C++ SDK's field name."""
+        return self.score
+
+    def __repr__(self) -> str:
+        coords = ", ".join(f"{value:.1f}" for value in self.box)
+        return f"Detection({self.name} {self.score:.3f} [{coords}])"
+
+
+class Detector:
+    """Run a exported LOFOP detector on images, without PyTorch.
+
+    Args:
+        model: Path to a ``.onnx`` file produced by
+            :func:`lofop.deploy.export_onnx`.
+        score_threshold: Minimum class score for a candidate to survive.
+        nms_iou: IoU threshold for class-aware NMS.
+        max_detections: Cap on detections returned per image.
+        class_names: Optional class-index to name mapping.
+        image_size: Model input side length. Inferred from the graph when it
+            is fixed; required (or defaulted to 640) for dynamic-shape models.
+        providers: ONNX Runtime execution providers, e.g.
+            ``["CUDAExecutionProvider", "CPUExecutionProvider"]``. Defaults to
+            whatever the installed runtime offers.
+        soft_nms: Use Soft-NMS score decay instead of greedy suppression.
+
+    Raises:
+        LofopError: If onnxruntime is missing, or the model cannot be loaded
+            or does not expose LOFOP's dense ``(boxes, scores)`` outputs.
+    """
+
+    def __init__(
+        self,
+        model: str | Path,
+        *,
+        score_threshold: float = 0.25,
+        nms_iou: float = 0.6,
+        max_detections: int = 300,
+        class_names: Sequence[str] | None = None,
+        image_size: int | None = None,
+        providers: Sequence[str] | None = None,
+        soft_nms: bool = False,
+    ) -> None:
+        self.model_path = Path(model)
+        if not self.model_path.is_file():
+            raise LofopError(
+                "ONNX model not found", context={"path": str(self.model_path)}
+            )
+        self.score_threshold = float(score_threshold)
+        self.nms_iou = float(nms_iou)
+        self.max_detections = int(max_detections)
+        self.soft_nms = bool(soft_nms)
+
+        self._session = self._open_session(providers)
+        outputs = [o.name for o in self._session.get_outputs()]
+        if len(outputs) < 2:
+            raise LofopError(
+                "Model does not expose LOFOP's dense (boxes, scores) outputs",
+                context={"outputs": outputs, "path": str(self.model_path)},
+            )
+        self._input_name = self._session.get_inputs()[0].name
+        self._output_names = outputs[:2]
+        self.image_size = image_size or self._infer_image_size()
+        self._class_names = list(class_names) if class_names else None
+        logger.info(
+            "Loaded %s (input %d, ops backend %s)",
+            self.model_path.name, self.image_size, ops_backend(),
+        )
+
+    # -- construction helpers ----------------------------------------------
+
+    def _open_session(self, providers: Sequence[str] | None):
+        """Create the ONNX Runtime session, with an actionable error if absent."""
+        try:
+            import onnxruntime
+        except ImportError as exc:
+            raise LofopError(
+                "onnxruntime is required for lofop.runtime: "
+                "pip install onnxruntime (or onnxruntime-gpu)",
+            ) from exc
+        try:
+            kwargs: dict[str, Any] = {}
+            if providers is not None:
+                kwargs["providers"] = list(providers)
+            return onnxruntime.InferenceSession(str(self.model_path), **kwargs)
+        except Exception as exc:  # onnxruntime raises bare RuntimeError subclasses
+            raise LofopError(
+                f"Cannot load ONNX model: {exc}", context={"path": str(self.model_path)}
+            ) from exc
+
+    def _infer_image_size(self) -> int:
+        """Read the input side length from the graph, or fall back to 640."""
+        shape = self._session.get_inputs()[0].shape
+        if len(shape) == 4 and isinstance(shape[2], int) and shape[2] > 0:
+            return int(shape[2])
+        logger.debug("Model has dynamic input height; using %d", _DEFAULT_SIZE)
+        return _DEFAULT_SIZE
+
+    # -- inference ----------------------------------------------------------
+
+    def predict(
+        self, source: ImageSource, *, score_threshold: float | None = None
+    ) -> list[Detection]:
+        """Detect objects in one image; boxes come back in its own pixels.
+
+        Args:
+            source: An image path, or an :class:`~lofop.runtime.Image` whose
+                pixels you already hold.
+            score_threshold: Override the confidence cut for this call only.
+
+        Returns:
+            Detections sorted by descending score, at most
+            ``max_detections`` of them.
+        """
+        image = source if isinstance(source, Image) else Image.load(source)
+        threshold = self.score_threshold if score_threshold is None else float(score_threshold)
+
+        tensor, meta = letterbox(
+            image.pixels, image.width, image.height,
+            channels=image.channels, size=self.image_size,
+        )
+        boxes, scores = self._run(tensor)
+        # The same torch-free post-processing the documented deployment path
+        # uses: dense best-class decode plus class-aware NMS, both native.
+        detections = postprocess_dense(
+            boxes, scores,
+            score_threshold=threshold,
+            nms_iou=self.nms_iou,
+            max_detections=self.max_detections,
+            soft=self.soft_nms,
+        )
+        mapped = unletterbox_boxes(detections.boxes, meta)
+        return [
+            Detection(
+                box=(float(box[0]), float(box[1]), float(box[2]), float(box[3])),
+                score=float(score),
+                label=int(label),
+                name=self.class_name(int(label)),
+            )
+            for box, score, label in zip(mapped, detections.scores, detections.labels)
+        ]
+
+    def predict_batch(
+        self, sources: Sequence[ImageSource], *, score_threshold: float | None = None
+    ) -> list[list[Detection]]:
+        """Detect objects in several images; one result list per input."""
+        return [self.predict(item, score_threshold=score_threshold) for item in sources]
+
+    def _run(self, tensor: Sequence[float]) -> tuple[list[list[float]], list[list[float]]]:
+        """Execute the graph; return dense boxes (N,4) and scores (N,C)."""
+        size = self.image_size
+        try:
+            import numpy as np
+        except ImportError as exc:
+            raise LofopError(
+                "numpy is required for lofop.runtime: pip install numpy"
+            ) from exc
+        try:
+            batch = np.asarray(tensor, dtype=np.float32).reshape(1, 3, size, size)
+            raw_boxes, raw_scores = self._session.run(
+                self._output_names, {self._input_name: batch}
+            )
+        except Exception as exc:
+            raise LofopError(
+                f"Inference failed: {exc}", context={"path": str(self.model_path)}
+            ) from exc
+        boxes = np.asarray(raw_boxes).reshape(-1, 4).tolist()
+        scores_array = np.asarray(raw_scores)
+        scores = scores_array.reshape(-1, int(scores_array.shape[-1])).tolist()
+        return boxes, scores
+
+    # -- introspection -------------------------------------------------------
+
+    def class_name(self, label: int) -> str:
+        """Name for a class index, falling back to ``class_<index>``."""
+        if self._class_names and 0 <= label < len(self._class_names):
+            return self._class_names[label]
+        return f"class_{label}"
+
+    @property
+    def providers(self) -> list[str]:
+        """Execution providers the session is actually using."""
+        return list(self._session.get_providers())
+
+    @property
+    def ops_backend(self) -> str:
+        """Active native ops tier: ``cuda``, ``native``, or ``python``."""
+        return ops_backend()
+
+    def __repr__(self) -> str:
+        return (
+            f"Detector(model={self.model_path.name!r}, image_size={self.image_size}, "
+            f"providers={self.providers}, ops={self.ops_backend})"
+        )

--- a/lofop/runtime/image.py
+++ b/lofop/runtime/image.py
@@ -1,0 +1,90 @@
+"""Minimal image container for the LOFOP inference runtime.
+
+Deliberately small: an :class:`Image` is width, height, channel count, and a
+row-major 8-bit HWC buffer -- the same shape the C++ SDK's ``lofop::Image``
+holds, so the two runtimes accept the same inputs and the shared preprocessing
+kernel can consume either without a copy in the C++ case.
+
+Decoding is not this module's job. Pillow handles it here because the LOFOP
+core already depends on Pillow; production callers that already hold pixels
+(a decoded video frame, a camera buffer, a ``cv::Mat`` on the C++ side) pass
+them straight to :meth:`Image.from_pixels` and skip file I/O entirely.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from lofop.core.exceptions import DataError
+
+__all__ = ["Image"]
+
+
+@dataclass(frozen=True)
+class Image:
+    """An 8-bit image in row-major HWC layout.
+
+    Attributes:
+        width: Width in pixels.
+        height: Height in pixels.
+        channels: 1 (grayscale) or 3 (RGB).
+        pixels: ``height * width * channels`` bytes.
+    """
+
+    width: int
+    height: int
+    channels: int
+    pixels: bytes
+
+    def __post_init__(self) -> None:
+        if self.width <= 0 or self.height <= 0:
+            raise DataError(
+                "Image needs positive dimensions",
+                context={"width": self.width, "height": self.height},
+            )
+        if self.channels not in (1, 3):
+            raise DataError(
+                "Image supports 1 or 3 channels", context={"channels": self.channels}
+            )
+        expected = self.width * self.height * self.channels
+        if len(self.pixels) != expected:
+            raise DataError(
+                "Pixel buffer does not match the declared image size",
+                context={"expected": expected, "got": len(self.pixels)},
+            )
+
+    @classmethod
+    def from_pixels(
+        cls, pixels: bytes | bytearray, width: int, height: int, channels: int = 3
+    ) -> Image:
+        """Wrap an existing HWC 8-bit buffer without decoding or copying it."""
+        return cls(width, height, channels, bytes(pixels))
+
+    @classmethod
+    def load(cls, path: str | Path) -> Image:
+        """Decode an image file (any format Pillow reads) into RGB.
+
+        Raises:
+            DataError: If the file cannot be opened or decoded.
+        """
+        try:
+            from PIL import Image as PILImage
+        except ImportError as exc:  # pragma: no cover - Pillow is a core dep
+            raise DataError("Pillow is required to load image files") from exc
+        try:
+            with PILImage.open(path) as handle:
+                rgb = handle.convert("RGB")
+                return cls(rgb.width, rgb.height, 3, rgb.tobytes())
+        except OSError as exc:
+            raise DataError(
+                f"Cannot load image: {exc}", context={"path": str(path)}
+            ) from exc
+
+    @property
+    def size(self) -> tuple[int, int]:
+        """``(width, height)`` in pixels."""
+        return self.width, self.height
+
+    def __repr__(self) -> str:
+        return f"Image({self.width}x{self.height}, channels={self.channels})"

--- a/lofop/sdk.py
+++ b/lofop/sdk.py
@@ -107,6 +107,9 @@ class Detector:
         num_keypoints: Keypoints per instance for pose variants (default 17,
             the COCO person skeleton). Ignored by detection/segmentation
             models.
+        nms_mode: Duplicate-removal strategy: ``"greedy"`` (default),
+            ``"soft"`` (score decay, better in crowds), or ``"free"``
+            (NMS-free peak selection -- no suppression loop at all).
 
     Attributes:
         model: The underlying :class:`LofopDetect` torch module -- fully
@@ -123,6 +126,7 @@ class Detector:
         image_size: int = 640,
         device: str | None = None,
         num_keypoints: int | None = None,
+        nms_mode: str | None = None,
     ) -> None:
         self.device = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
         self.image_size = image_size
@@ -143,6 +147,13 @@ class Detector:
         self.class_names = list(class_names) if class_names else [
             f"class_{i}" for i in range(self.model.head.num_classes)
         ]
+        if nms_mode is not None:
+            if nms_mode not in LofopDetect._NMS_MODES:
+                raise ModelError(
+                    "Unknown nms_mode",
+                    context={"got": nms_mode, "known": list(LofopDetect._NMS_MODES)},
+                )
+            self.model.nms_mode = nms_mode
         if checkpoint is not None:
             self.model.load_state_dict(load_checkpoint_state(checkpoint))
             logger.info("Loaded weights from %s", checkpoint)

--- a/lofop/version.py
+++ b/lofop/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the LOFOP package version."""
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lofop"
-version = "1.2.0"
+version = "1.2.1"
 description = "LOFOP: a modular, enterprise-grade computer vision framework."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/models/test_nms_modes.py
+++ b/tests/models/test_nms_modes.py
@@ -1,0 +1,76 @@
+"""Tests for the inference nms_mode options: greedy, soft, and NMS-free."""
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+import lofop.models  # noqa: E402, F401  (registers model components)
+from lofop.core.config import Config  # noqa: E402
+from lofop.core.exceptions import LofopError, ModelError  # noqa: E402
+from lofop.registries import HUB  # noqa: E402
+
+
+def build(nms_mode="greedy"):
+    cfg = Config.load("lofop/configs/lofop-detect/n.yaml", resolve=False)
+    cfg.num_classes = 2
+    cfg.resolve()
+    model = HUB.build(cfg.model, nms_mode=nms_mode).eval()
+    model.score_threshold = 0.05
+    return model
+
+
+class TestNmsModes:
+    def test_unknown_mode_rejected(self):
+        with pytest.raises(LofopError):  # ModelError, wrapped by the builder
+            build(nms_mode="nope")
+
+    def test_sdk_rejects_unknown_mode(self):
+        from lofop import Detector
+
+        with pytest.raises(ModelError):
+            Detector("n", num_classes=2, image_size=64, device="cpu", nms_mode="hard")
+
+    @pytest.mark.parametrize("mode", ["greedy", "soft", "free"])
+    def test_all_modes_produce_valid_output(self, mode):
+        torch.manual_seed(0)
+        model = build(nms_mode=mode)
+        [result] = model.predict(torch.rand(1, 3, 64, 64))
+        k = result["boxes"].shape[0]
+        assert result["scores"].shape == (k,) and result["labels"].shape == (k,)
+        assert k <= model.max_detections
+        if k > 1:  # scores stay descending in every mode
+            assert (result["scores"][:-1] >= result["scores"][1:]).all()
+
+    def test_free_mode_keeps_only_local_peaks(self):
+        torch.manual_seed(0)
+        model = build(nms_mode="free")
+        images = torch.rand(1, 3, 64, 64)
+        cls_out, _, quality_out = model.forward(images)
+        peaks = model._peak_mask(cls_out, quality_out)
+        # Peak selection must be strictly sparser than raw thresholding.
+        assert 0 < int(peaks.sum()) < peaks.shape[1]
+        [result] = model.predict(images)
+        greedy = build(nms_mode="greedy")
+        greedy.load_state_dict(model.state_dict())
+        [base] = greedy.predict(images)
+        assert result["boxes"].shape[0] <= max(base["boxes"].shape[0], 1) * 3
+
+    def test_soft_mode_decays_scores(self):
+        torch.manual_seed(0)
+        model = build(nms_mode="soft")
+        greedy = build(nms_mode="greedy")
+        greedy.load_state_dict(model.state_dict())
+        images = torch.rand(1, 3, 64, 64)
+        [soft] = model.predict(images)
+        [base] = greedy.predict(images)
+        # Soft keeps at least as many detections as greedy on the same input.
+        assert soft["boxes"].shape[0] >= base["boxes"].shape[0]
+
+    def test_task_variants_inherit_modes(self):
+        cfg = Config.load("lofop/configs/lofop-detect/n-seg.yaml", resolve=False)
+        cfg.num_classes = 2
+        cfg.resolve()
+        model = HUB.build(cfg.model, nms_mode="free").eval()
+        model.score_threshold = 0.05
+        [result] = model.predict(torch.rand(1, 3, 64, 64))
+        assert "masks" in result

--- a/tests/ops/test_preprocess.py
+++ b/tests/ops/test_preprocess.py
@@ -1,0 +1,194 @@
+"""Tests for the shared letterbox preprocessing.
+
+The point of these tests is parity. ``letterbox`` has a pure Python reference
+and a C++ kernel, and the C++ SDK compiles that same kernel, so a divergence
+between them would silently change detection accuracy between the training and
+serving paths with nothing to trace it to. The parity tests below are the
+guard that makes "Python trains, C++ serves" safe.
+"""
+
+from __future__ import annotations
+
+import random
+import struct
+
+import pytest
+
+from lofop.core.exceptions import DataError
+from lofop.ops.native import load_native
+from lofop.ops.preprocess import (
+    LetterboxMeta,
+    _letterbox_python,
+    letterbox,
+    unletterbox_boxes,
+)
+
+# The kernels compute in float32 while the Python reference computes in
+# float64, so agreement is expected to float32 epsilon (1.19e-7), not bit for
+# bit. Sampling positions are deliberately computed in double on both sides to
+# keep the gap this small even on heavy downscales.
+FLOAT32_EPS = 1.2e-07
+
+
+def native_letterbox_available() -> bool:
+    """True when a compiled library exposing the letterbox kernel is loaded."""
+    lib = load_native()
+    return lib is not None and hasattr(lib, "lofop_letterbox")
+
+
+def random_pixels(width: int, height: int, channels: int, seed: int) -> bytes:
+    rng = random.Random(seed)
+    return bytes(rng.randrange(256) for _ in range(width * height * channels))
+
+
+class TestGeometry:
+    def test_preserves_aspect_ratio_with_symmetric_padding(self):
+        # 128x96 is 4:3; at 64px the image occupies 64x48 with 8px bands.
+        _, meta = letterbox(bytes(128 * 96 * 3), 128, 96, size=64)
+        assert meta.scale == pytest.approx(0.5)
+        assert (meta.pad_left, meta.pad_top) == (0.0, 8.0)
+
+    def test_pads_the_other_axis_for_tall_images(self):
+        _, meta = letterbox(bytes(48 * 96 * 3), 48, 96, size=64)
+        assert meta.scale == pytest.approx(64 / 96)
+        assert meta.pad_top == 0.0
+        assert meta.pad_left > 0.0
+
+    def test_square_image_needs_no_padding(self):
+        _, meta = letterbox(bytes(40 * 40 * 3), 40, 40, size=20)
+        assert (meta.pad_left, meta.pad_top) == (0.0, 0.0)
+        assert meta.scale == pytest.approx(0.5)
+
+    def test_output_is_chw_float_in_unit_range(self):
+        tensor, _ = letterbox(random_pixels(20, 12, 3, seed=1), 20, 12, size=16)
+        assert len(tensor) == 3 * 16 * 16
+        assert all(0.0 <= value <= 1.0 for value in tensor)
+
+    def test_padding_uses_the_requested_fill(self):
+        # A 32x8 source at size 16 leaves padded rows top and bottom.
+        tensor, meta = letterbox(bytes(32 * 8 * 3), 32, 8, size=16, pad_value=0.25)
+        assert meta.pad_top > 0
+        assert tensor[0] == pytest.approx(0.25)  # first row is padding
+
+    def test_grayscale_is_broadcast_to_three_channels(self):
+        pixels = random_pixels(8, 8, 1, seed=2)
+        tensor, _ = letterbox(pixels, 8, 8, channels=1, size=8)
+        plane = 8 * 8
+        assert tensor[:plane] == tensor[plane:2 * plane] == tensor[2 * plane:]
+
+    def test_uniform_image_survives_the_round_trip(self):
+        # Every pixel 128 -> every non-padded output value 128/255.
+        tensor, meta = letterbox(bytes([128]) * (16 * 16 * 3), 16, 16, size=8)
+        assert all(value == pytest.approx(128 / 255, abs=1e-6) for value in tensor)
+        assert (meta.pad_left, meta.pad_top) == (0.0, 0.0)
+
+
+class TestValidation:
+    @pytest.mark.parametrize(
+        "width,height,size",
+        [(0, 10, 8), (10, 0, 8), (10, 10, 0), (-4, 10, 8)],
+    )
+    def test_rejects_non_positive_dimensions(self, width, height, size):
+        with pytest.raises(DataError):
+            letterbox(bytes(max(width, 1) * max(height, 1) * 3), width, height, size=size)
+
+    def test_rejects_unsupported_channel_counts(self):
+        with pytest.raises(DataError):
+            letterbox(bytes(4 * 4 * 4), 4, 4, channels=4, size=4)
+
+    def test_rejects_a_short_pixel_buffer(self):
+        with pytest.raises(DataError):
+            letterbox(bytes(10), 8, 8, size=8)
+
+    def test_rejects_a_degenerate_meta_on_inverse(self):
+        with pytest.raises(DataError):
+            unletterbox_boxes([[0, 0, 1, 1]], LetterboxMeta(0.0, 0.0, 0.0, 10, 10))
+
+
+class TestInverseMapping:
+    def test_maps_the_full_frame_back_to_the_original(self):
+        _, meta = letterbox(bytes(128 * 96 * 3), 128, 96, size=64)
+        boxed = [[
+            meta.pad_left, meta.pad_top,
+            meta.pad_left + 128 * meta.scale, meta.pad_top + 96 * meta.scale,
+        ]]
+        assert unletterbox_boxes(boxed, meta)[0] == pytest.approx([0, 0, 128, 96], abs=1e-3)
+
+    def test_clamps_boxes_to_the_image_bounds(self):
+        meta = LetterboxMeta(scale=0.5, pad_left=0.0, pad_top=8.0, width=128, height=96)
+        # A box running off every edge must come back inside the image.
+        result = unletterbox_boxes([[-50.0, -50.0, 500.0, 500.0]], meta)[0]
+        assert result == pytest.approx([0.0, 0.0, 128.0, 96.0])
+
+    def test_empty_input_returns_empty(self):
+        meta = LetterboxMeta(0.5, 0.0, 0.0, 10, 10)
+        assert unletterbox_boxes([], meta) == []
+
+    def test_round_trips_an_interior_box(self):
+        _, meta = letterbox(bytes(200 * 100 * 3), 200, 100, size=64)
+        original = [[20.0, 30.0, 90.0, 80.0]]
+        boxed = [[
+            original[0][0] * meta.scale + meta.pad_left,
+            original[0][1] * meta.scale + meta.pad_top,
+            original[0][2] * meta.scale + meta.pad_left,
+            original[0][3] * meta.scale + meta.pad_top,
+        ]]
+        assert unletterbox_boxes(boxed, meta)[0] == pytest.approx(original[0], abs=1e-3)
+
+
+@pytest.mark.skipif(
+    not native_letterbox_available(),
+    reason="native ops library not built; build_native() enables the parity check",
+)
+class TestNativeParity:
+    """The C++ kernel and the Python reference must agree.
+
+    The C++ SDK compiles the very same kernel, so these assertions cover the
+    C++ runtime too: if Python and the kernel agree, all three paths agree.
+    """
+
+    CASES = [
+        (64, 48, 32, 3),     # ordinary downscale, pads vertically
+        (17, 40, 16, 3),     # tall, pads horizontally
+        (40, 40, 20, 3),     # square, no padding
+        (9, 3, 8, 1),        # grayscale, extreme aspect ratio
+        (31, 17, 13, 3),     # odd sizes, non-integer scale
+        (5, 5, 5, 3),        # identity scale
+        (1, 1, 4, 3),        # upscale from a single pixel
+        (100, 37, 24, 3),    # heavy downscale, where float error concentrates
+        (200, 13, 16, 3),    # extreme aspect ratio
+    ]
+
+    @pytest.mark.parametrize("width,height,size,channels", CASES)
+    def test_pixels_match_the_reference(self, width, height, size, channels):
+        pixels = random_pixels(width, height, channels, seed=width * 31 + height)
+        native, _ = letterbox(pixels, width, height, channels=channels, size=size)
+        reference, _ = _letterbox_python(pixels, width, height, channels, size, 0.447)
+        assert len(native) == len(reference)
+        worst = max(abs(a - b) for a, b in zip(native, reference))
+        assert worst <= FLOAT32_EPS, f"C++ and Python diverged by {worst:.3e}"
+
+    @pytest.mark.parametrize("width,height,size,channels", CASES)
+    def test_geometry_matches_the_reference(self, width, height, size, channels):
+        pixels = random_pixels(width, height, channels, seed=7)
+        _, native_meta = letterbox(pixels, width, height, channels=channels, size=size)
+        _, reference_meta = _letterbox_python(pixels, width, height, channels, size, 0.447)
+        as_float32 = struct.unpack("f", struct.pack("f", reference_meta.scale))[0]
+        assert native_meta.scale == as_float32
+        assert native_meta.pad_left == reference_meta.pad_left
+        assert native_meta.pad_top == reference_meta.pad_top
+
+    def test_inverse_mapping_matches_the_reference(self):
+        meta = LetterboxMeta(scale=0.375, pad_left=3.0, pad_top=11.0, width=90, height=70)
+        boxes = [[4.0, 12.0, 40.0, 44.0], [-5.0, 0.0, 900.0, 900.0], [0.0, 0.0, 0.0, 0.0]]
+        native = unletterbox_boxes(boxes, meta)
+        expected = []
+        for box in boxes:
+            expected.append([
+                min(max((box[0] - meta.pad_left) / meta.scale, 0.0), 90.0),
+                min(max((box[1] - meta.pad_top) / meta.scale, 0.0), 70.0),
+                min(max((box[2] - meta.pad_left) / meta.scale, 0.0), 90.0),
+                min(max((box[3] - meta.pad_top) / meta.scale, 0.0), 70.0),
+            ])
+        for actual, wanted in zip(native, expected):
+            assert actual == pytest.approx(wanted, abs=1e-4)

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -1,0 +1,227 @@
+"""Tests for the torch-free ONNX runtime (``lofop.runtime``).
+
+The expected detections here are the same ones ``cpp/tests/test_lofop.cpp``
+asserts, driven by the same stub outputs. Pinning both suites to identical
+numbers is what makes the dual-language claim testable: if the Python runtime
+and the C++ SDK ever disagree on a shared model, one of the two suites breaks.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from lofop.core.exceptions import DataError, LofopError
+from lofop.runtime import Detection, Detector, Image
+
+onnx = pytest.importorskip("onnx", reason="onnx is needed to build the stub model")
+pytest.importorskip("onnxruntime", reason="onnxruntime is needed to run the stub model")
+np = pytest.importorskip("numpy", reason="numpy is needed by the runtime")
+
+SIZE = 64
+NUM_CANDIDATES = 4
+NUM_CLASSES = 3
+
+# Two overlapping class-0 boxes (the weaker must be suppressed), one class-1
+# box, and one candidate below the default 0.25 threshold.
+STUB_BOXES = [[10, 10, 30, 30], [11, 11, 31, 31], [40, 40, 60, 60], [0, 0, 5, 5]]
+STUB_SCORES = [(0, 0.9), (0, 0.8), (1, 0.7), (2, 0.1)]
+
+
+@pytest.fixture(scope="module")
+def stub_model(tmp_path_factory) -> str:
+    """An ONNX graph with LOFOP's dense (boxes, scores) output contract."""
+    from onnx import TensorProto, helper
+
+    boxes = np.array([STUB_BOXES], dtype=np.float32)
+    scores = np.zeros((1, NUM_CANDIDATES, NUM_CLASSES), dtype=np.float32)
+    for row, (label, score) in enumerate(STUB_SCORES):
+        scores[0, row, label] = score
+
+    graph = helper.make_graph(
+        [
+            helper.make_node(
+                "Constant", [], ["boxes"],
+                value=helper.make_tensor(
+                    "b", TensorProto.FLOAT, [1, NUM_CANDIDATES, 4], boxes.flatten()
+                ),
+            ),
+            helper.make_node(
+                "Constant", [], ["scores"],
+                value=helper.make_tensor(
+                    "s", TensorProto.FLOAT, [1, NUM_CANDIDATES, NUM_CLASSES], scores.flatten()
+                ),
+            ),
+        ],
+        "lofop_stub",
+        [helper.make_tensor_value_info("images", TensorProto.FLOAT, [1, 3, SIZE, SIZE])],
+        [
+            helper.make_tensor_value_info("boxes", TensorProto.FLOAT, [1, NUM_CANDIDATES, 4]),
+            helper.make_tensor_value_info(
+                "scores", TensorProto.FLOAT, [1, NUM_CANDIDATES, NUM_CLASSES]
+            ),
+        ],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 18)])
+    model.ir_version = 9
+    onnx.checker.check_model(model)
+    path = tmp_path_factory.mktemp("runtime") / "stub.onnx"
+    onnx.save(model, str(path))
+    return str(path)
+
+
+@pytest.fixture
+def frame() -> Image:
+    """A 128x96 (4:3) image: letterboxed to 64 it scales by 0.5 and pads 8px."""
+    return Image.from_pixels(bytes(128 * 96 * 3), 128, 96, 3)
+
+
+class TestImage:
+    def test_from_pixels_reports_its_shape(self, frame):
+        assert frame.size == (128, 96)
+        assert frame.channels == 3
+
+    def test_rejects_a_mismatched_buffer(self):
+        with pytest.raises(DataError):
+            Image.from_pixels(bytes(10), 8, 8, 3)
+
+    def test_rejects_unsupported_channels(self):
+        with pytest.raises(DataError):
+            Image.from_pixels(bytes(4 * 4 * 4), 4, 4, 4)
+
+    def test_loads_a_file(self, tmp_path):
+        pil = pytest.importorskip("PIL.Image")
+        path = tmp_path / "frame.png"
+        pil.new("RGB", (32, 24), (10, 20, 30)).save(path)
+        image = Image.load(path)
+        assert image.size == (32, 24)
+        assert image.channels == 3
+
+    def test_reports_a_missing_file_clearly(self, tmp_path):
+        with pytest.raises(DataError):
+            Image.load(tmp_path / "nope.png")
+
+
+class TestDetector:
+    def test_reads_input_size_from_the_graph(self, stub_model):
+        assert Detector(stub_model).image_size == SIZE
+
+    def test_rejects_a_missing_model(self, tmp_path):
+        with pytest.raises(LofopError):
+            Detector(tmp_path / "missing.onnx")
+
+    def test_suppresses_duplicates_and_weak_candidates(self, stub_model, frame):
+        results = Detector(stub_model).predict(frame)
+        # 4 candidates in: one duplicate suppressed by NMS, one below threshold.
+        assert len(results) == 2
+
+    def test_maps_boxes_back_to_original_coordinates(self, stub_model, frame):
+        results = Detector(stub_model).predict(frame)
+        # scale 0.5, pad_top 8: x_src = x / 0.5, y_src = (y - 8) / 0.5.
+        assert results[0].box == pytest.approx((20.0, 4.0, 60.0, 44.0), abs=1e-3)
+        # The second box runs past the bottom edge and must be clamped.
+        assert results[1].box == pytest.approx((80.0, 64.0, 120.0, 96.0), abs=1e-3)
+
+    def test_orders_detections_by_confidence(self, stub_model, frame):
+        results = Detector(stub_model).predict(frame)
+        assert results[0].score == pytest.approx(0.9, abs=1e-5)
+        assert results[1].score == pytest.approx(0.7, abs=1e-5)
+        assert results[0].score >= results[1].score
+
+    def test_confidence_aliases_score(self, stub_model, frame):
+        hit = Detector(stub_model).predict(frame)[0]
+        assert hit.confidence == hit.score
+
+    def test_applies_class_names(self, stub_model, frame):
+        detector = Detector(stub_model, class_names=["cat", "dog", "bird"])
+        assert [hit.name for hit in detector.predict(frame)] == ["cat", "dog"]
+
+    def test_falls_back_to_indexed_names(self, stub_model, frame):
+        assert Detector(stub_model).predict(frame)[0].name == "class_0"
+
+    def test_threshold_override_applies_per_call(self, stub_model, frame):
+        detector = Detector(stub_model)
+        assert len(detector.predict(frame, score_threshold=0.75)) == 1
+        # The override must not persist into the next call.
+        assert len(detector.predict(frame)) == 2
+
+    def test_constructor_threshold_is_respected(self, stub_model, frame):
+        assert len(Detector(stub_model, score_threshold=0.95).predict(frame)) == 0
+
+    def test_accepts_an_image_path(self, stub_model, tmp_path):
+        pil = pytest.importorskip("PIL.Image")
+        path = tmp_path / "frame.png"
+        pil.new("RGB", (128, 96), (40, 50, 60)).save(path)
+        assert len(Detector(stub_model).predict(path)) == 2
+
+    def test_predict_batch_returns_one_list_per_image(self, stub_model, frame):
+        results = Detector(stub_model).predict_batch([frame, frame])
+        assert len(results) == 2
+        assert all(len(item) == 2 for item in results)
+
+    def test_soft_nms_retains_decayed_duplicates(self, stub_model, frame):
+        results = Detector(stub_model, soft_nms=True).predict(frame)
+        assert len(results) >= 2
+
+    def test_reports_its_backends(self, stub_model):
+        detector = Detector(stub_model)
+        assert any("CPU" in provider for provider in detector.providers)
+        assert detector.ops_backend in {"cuda", "native", "python"}
+
+    def test_repr_is_informative(self, stub_model):
+        assert "stub.onnx" in repr(Detector(stub_model))
+
+
+class TestDetection:
+    def test_is_immutable(self):
+        hit = Detection(box=(0.0, 0.0, 1.0, 1.0), score=0.5, label=0, name="cat")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            hit.score = 0.9
+
+    def test_repr_shows_name_and_score(self):
+        hit = Detection(box=(0.0, 0.0, 1.0, 1.0), score=0.5, label=0, name="cat")
+        assert "cat" in repr(hit) and "0.500" in repr(hit)
+
+
+class TestIsolationFromTheTrainingApi:
+    """The runtime must neither depend on, nor disturb, the PyTorch SDK."""
+
+    def test_importing_the_runtime_does_not_import_torch(self):
+        """Deployment images omit PyTorch entirely, so this must hold.
+
+        Checked in a clean interpreter: asserting on ``sys.modules`` in-process
+        would pass merely because no earlier test imported torch.
+        """
+        import subprocess
+        import sys
+
+        result = subprocess.run(
+            [
+                sys.executable, "-c",
+                "import sys; import lofop.runtime;"
+                " assert 'torch' not in sys.modules, sorted(sys.modules);"
+                " print('clean')",
+            ],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "clean" in result.stdout
+
+    def test_the_two_detectors_are_distinct_apis(self):
+        """``lofop.Detector`` (training) and ``lofop.runtime.Detector`` (serving).
+
+        Neither shadows the other: they live in different modules and are
+        reached by different imports, so adding the runtime cannot change what
+        existing ``from lofop import Detector`` code resolves to.
+        """
+        import importlib.util
+
+        import lofop
+
+        assert Detector.__module__ == "lofop.runtime.detector"
+        # The training SDK is still the name exported from the package root...
+        assert "Detector" in lofop.__all__
+        # ...and still lives in its own module, which find_spec locates without
+        # executing it (importing lofop.sdk would require torch).
+        assert importlib.util.find_spec("lofop.sdk") is not None


### PR DESCRIPTION
## Summary

What does this change do, and why?

## Changes

- 

## Test plan

Commands you ran and their results:

```
ruff check lofop tests benchmarks examples
python -m pytest tests/ -q
```

## Checklist

- [ ] Tests added or updated for the change
- [ ] `ruff check` is clean
- [ ] `pytest` passes locally
- [ ] Docs updated (`MANUAL.md` / `docs/`) if user-facing
- [ ] `CHANGELOG.md` updated under "Unreleased"
- [ ] Public APIs remain backward compatible (or the break is justified above)
